### PR TITLE
update to fully disable auth

### DIFF
--- a/server/app/core/auth.py
+++ b/server/app/core/auth.py
@@ -1,15 +1,14 @@
 from datetime import datetime, timedelta
-from typing import Optional
 
 from fastapi import Depends, HTTPException, status
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError, jwt
 
 from app.core.config import get_settings
 
 # Create two security schemes:
 # 1. When auth is enabled: Required bearer token
-# 2. When auth is disabled: Optional bearer token
+# 2. When auth is disabled: Optional bearer token (for testing)
 security = HTTPBearer(auto_error=not get_settings().auth_disabled)
 
 
@@ -49,7 +48,7 @@ def verify_token(token: str) -> dict:
 
 
 async def verify_auth(
-    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
 ) -> dict:
     """
     Dependency to verify JWT token from Authorization header
@@ -58,7 +57,7 @@ async def verify_auth(
     # Check if authentication is disabled in config
     if get_settings().auth_disabled:
         return {"sub": "guest_user"}
-        
+
     # At this point, auth is enabled, and we should have credentials
     # If not, it means auto_error=False, so we need to raise the error manually
     if credentials is None:
@@ -67,6 +66,6 @@ async def verify_auth(
             detail="Not authenticated",
             headers={"WWW-Authenticate": "Bearer"},
         )
-        
+
     # Normal authentication flow with token verification
     return verify_token(credentials.credentials)


### PR DESCRIPTION
Hey, not sure if this is the right approach, it's just what cursor gave to me. But if I just set the config.yaml file to 'auth_disabled: true' then it still was requiring auth. The readme said ` you can disable authentication by editing the app/core/auth.py`, but I wasn't sure what to do to disable there. So perhaps this just could be a readme fix to explain how to disable the authentication there. But this seemed to work, and uses the config yaml file to disable it.