### PR TITLE
rm: deployment script contained old sqlite

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.0
+    rev: v0.12.9
     hooks:
     -   id: ruff
         args: [--fix]
     -   id: ruff-format
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v6.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -18,7 +18,7 @@ repos:
         args: ['--maxkb=2000']  # Allow up to 2MB for lock files
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v1.17.1
     hooks:
     -   id: mypy
         additional_dependencies:

--- a/deploy.sh
+++ b/deploy.sh
@@ -31,10 +31,7 @@ sudo apt-get update
 sudo apt-get upgrade -y
 
 echo "Installing system dependencies..."
-sudo apt-get install -y \
-    sqlite3 \
-    libsqlite3-dev \
-    curl
+sudo apt-get install -y  curl
 
 echo "Installing Pixi..."
 if command -v pixi &> /dev/null; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,7 +167,7 @@ httpx = ">=0.24.0"
 pytest-aioboto3 = "*"
 
 [tool.pixi.feature.lint.dependencies]
-pre-commit = ">=3.3.2"
+pre-commit = ">=4"
 ruff = ">=0.7"
 mypy = "*"
 


### PR DESCRIPTION
Had to remove an item from the deployment script that was missed when migrating to dynamodb. As part of hardening the Deep Learning AMI in `ftw-api-deployment` I noticed this was still here. 