### PR TITLE
feat: add model requirements to GET /v1/ endpoint

### DIFF
--- a/server/app/schemas/parameters.py
+++ b/server/app/schemas/parameters.py
@@ -9,6 +9,12 @@ class ModelInfo(BaseModel):
     description: str
     license: str
     version: str
+    requires_window: bool = Field(
+        description="Whether this model requires window A and B images"
+    )
+    requires_polygonize: bool = Field(
+        description="Whether this model requires polygonization step"
+    )
 
 
 class TaskInfo(BaseModel):

--- a/server/config/base.toml
+++ b/server/config/base.toml
@@ -71,6 +71,8 @@ description = "2-Class model trained on the full FTW dataset for field boundary 
 license = "proprietary"
 version = "v1"
 file = "2_Class_FULL_FTW_Pretrained.ckpt"
+requires_window = true
+requires_polygonize = true
 
 [[models]]
 id = "2_Class_CCBY_FTW_Pretrained"
@@ -79,6 +81,8 @@ description = "2-Class model trained on a limited FTW dataset for field boundary
 license = "CC-BY-4.0"
 version = "v1"
 file = "2_Class_CCBY_FTW_Pretrained.ckpt"
+requires_window = true
+requires_polygonize = true
 
 [[models]]
 id = "3_Class_FULL_FTW_Pretrained"
@@ -87,6 +91,8 @@ description = "3-Class model trained on the full FTW dataset for field boundary 
 license = "proprietary"
 version = "v1"
 file = "3_Class_FULL_FTW_Pretrained.ckpt"
+requires_window = true
+requires_polygonize = true
 
 [[models]]
 id = "3_Class_CCBY_FTW_Pretrained"
@@ -95,3 +101,5 @@ description = "3-Class model trained on a limited FTW dataset for field boundary
 license = "CC-BY-4.0"
 version = "v1"
 file = "3_Class_CCBY_FTW_Pretrained.ckpt"
+requires_window = true
+requires_polygonize = true


### PR DESCRIPTION
- Add requires_window and requires_polygonize fields to ModelInfo schema
- Update base.toml configuration with requirement flags for all models
- All models set to require both window images and polygonization
- Resolves #33

The GET /v1/ endpoint now returns enhanced model information including:
- requires_window: boolean indicating if model needs window A and B images
- requires_polygonize: boolean indicating if model needs polygonization step