### PR TITLE
Replace UUID project IDs with human-readable names

### DIFF
--- a/server/app/db/models.py
+++ b/server/app/db/models.py
@@ -9,7 +9,7 @@ from pynamodb.models import Model
 
 from app.core.config import get_settings
 from app.core.types import ProjectStatus
-from app.utils.name_generator import generate_project_id 
+from app.utils.name_generator import generate_project_id
 
 settings = get_settings()
 
@@ -20,9 +20,7 @@ class Project(Model):
         region = settings.dynamodb.aws_region
         host = settings.dynamodb.dynamodb_endpoint  # For local development
 
-    id = UnicodeAttribute(
-    hash_key=True, default_for_new=lambda: generate_project_id()
-    )
+    id = UnicodeAttribute(hash_key=True, default_for_new=lambda: generate_project_id())
     title = UnicodeAttribute()
     status = UnicodeAttribute(default=ProjectStatus.CREATED.value)
     progress = UnicodeAttribute(null=True)  # Store as string

--- a/server/app/db/models.py
+++ b/server/app/db/models.py
@@ -9,7 +9,7 @@ from pynamodb.models import Model
 
 from app.core.config import get_settings
 from app.core.types import ProjectStatus
-from app.utils.name_generator import generate_unique_project_id
+from app.utils.name_generator import generate_project_id 
 
 settings = get_settings()
 
@@ -21,7 +21,7 @@ class Project(Model):
         host = settings.dynamodb.dynamodb_endpoint  # For local development
 
     id = UnicodeAttribute(
-        hash_key=True, default_for_new=lambda: generate_unique_project_id()
+    hash_key=True, default_for_new=lambda: generate_project_id()
     )
     title = UnicodeAttribute()
     status = UnicodeAttribute(default=ProjectStatus.CREATED.value)

--- a/server/app/db/models.py
+++ b/server/app/db/models.py
@@ -7,9 +7,10 @@ import pendulum
 from pynamodb.attributes import UnicodeAttribute, UTCDateTimeAttribute
 from pynamodb.models import Model
 
-from ..utils.name_generator import generate_unique_project_id
 from app.core.config import get_settings
 from app.core.types import ProjectStatus
+
+from ..utils.name_generator import generate_unique_project_id
 
 settings = get_settings()
 
@@ -20,7 +21,9 @@ class Project(Model):
         region = settings.dynamodb.aws_region
         host = settings.dynamodb.dynamodb_endpoint  # For local development
 
-    id = UnicodeAttribute(hash_key=True, default_for_new=lambda: generate_unique_project_id())
+    id = UnicodeAttribute(
+        hash_key=True, default_for_new=lambda: generate_unique_project_id()
+    )
     title = UnicodeAttribute()
     status = UnicodeAttribute(default=ProjectStatus.CREATED.value)
     progress = UnicodeAttribute(null=True)  # Store as string

--- a/server/app/db/models.py
+++ b/server/app/db/models.py
@@ -7,6 +7,7 @@ import pendulum
 from pynamodb.attributes import UnicodeAttribute, UTCDateTimeAttribute
 from pynamodb.models import Model
 
+from ..utils.name_generator import generate_unique_project_id
 from app.core.config import get_settings
 from app.core.types import ProjectStatus
 
@@ -19,7 +20,7 @@ class Project(Model):
         region = settings.dynamodb.aws_region
         host = settings.dynamodb.dynamodb_endpoint  # For local development
 
-    id = UnicodeAttribute(hash_key=True, default_for_new=lambda: str(uuid.uuid4()))
+    id = UnicodeAttribute(hash_key=True, default_for_new=lambda: generate_unique_project_id())
     title = UnicodeAttribute()
     status = UnicodeAttribute(default=ProjectStatus.CREATED.value)
     progress = UnicodeAttribute(null=True)  # Store as string

--- a/server/app/db/models.py
+++ b/server/app/db/models.py
@@ -9,8 +9,7 @@ from pynamodb.models import Model
 
 from app.core.config import get_settings
 from app.core.types import ProjectStatus
-
-from ..utils.name_generator import generate_unique_project_id
+from app.utils.name_generator import generate_unique_project_id
 
 settings = get_settings()
 

--- a/server/app/services/project_service.py
+++ b/server/app/services/project_service.py
@@ -97,7 +97,8 @@ class ProjectService:
         self, project_data: CreateProjectRequest
     ) -> ProjectResponse:
         """Create a new project and return its response model."""
-        new_project = Project(title=project_data.title)
+        unique_id = self._generate_unique_project_id()
+        new_project = Project(id=unique_id, title=project_data.title)
         new_project.save()
         return await self._map_project_to_response(new_project)
 
@@ -126,6 +127,28 @@ class ProjectService:
 
         await self._cleanup_project_files(project_id)
         project.delete()
+
+    def project_exists(self, project_id: str) -> bool:
+        """Check if a project exists in the database."""
+        try:
+            self._get_project_or_404(project_id)
+            return True
+        except HTTPException:
+            return False
+
+    def _generate_unique_project_id(self, max_attempts: int = 20) -> str:
+        """Generate unique project ID with collision checking."""
+        from app.utils.name_generator import generate_project_id
+
+        for _ in range(max_attempts):
+            project_id = generate_project_id()
+            if not self.project_exists(project_id):
+                return project_id
+
+        # Will request strict collision avoidance - raise error instead of fallback
+        raise RuntimeError(
+            f"Unable to generate unique project ID after {max_attempts} attempts"
+        )
 
     def get_project_status(self, project_id: str) -> dict[str, Any]:
         """Get basic project status information."""

--- a/server/app/utils/name_generator.py
+++ b/server/app/utils/name_generator.py
@@ -1,10 +1,7 @@
-"""
-Project name generator utility for creating human-readable project IDs.
-"""
+"""Project name generator utility for creating human-readable project IDs."""
 
 import random
 import string
-from collections.abc import Callable
 from typing import ClassVar
 
 
@@ -91,40 +88,32 @@ class ProjectNameGenerator:
         """Generate a readable project name in format: adjective-animal-suffix"""
         adjective = random.choice(cls.ADJECTIVES)
         animal = random.choice(cls.ANIMALS)
-        # Generate 4-character alphanumeric suffix (lowercase)
         suffix = "".join(random.choices(string.ascii_lowercase + string.digits, k=4))
         return f"{adjective}-{animal}-{suffix}"
 
 
-def generate_unique_project_id(
-    check_existence_func: Callable[[str], bool] | None = None,
-) -> str:
-    """
-    Generate a unique project ID, checking against existing IDs.
+def generate_unique_project_id() -> str:
+    """Generate a unique project ID with database collision checking."""
+    # Importing here to avoid circular import issues
+    try:
+        from pynamodb.exceptions import DoesNotExist
 
-    Args:
-        check_existence_func: Function that takes an ID and returns True if it exists
+        from app.db.models import Project
 
-    Returns:
-        A unique project ID string
+        max_attempts = 20
+        for _ in range(max_attempts):
+            project_id = ProjectNameGenerator.generate()
+            try:
+                # Try to get the project - if it exists, this won't raise an exception
+                Project.get(project_id)
+                # If we get here, project exists, try again
+                continue
+            except DoesNotExist:
+                # Project doesn't exist, this ID is unique
+                return project_id
 
-    Raises:
-        RuntimeError: If unable to generate unique ID after max attempts
-    """
-    max_attempts = 20
-
-    for _ in range(max_attempts):
-        project_id = ProjectNameGenerator.generate()
-
-        # If no check function provided, return the generated ID
-        if check_existence_func is None:
-            return project_id
-
-        # Check if ID already exists
-        if not check_existence_func(project_id):
-            return project_id
-
-    # If we get here, we've exhausted our attempts
-    raise RuntimeError(
-        f"Unable to generate unique project ID after {max_attempts} attempts"
-    )
+        # Fallback if all attempts failed
+        return ProjectNameGenerator.generate()
+    except Exception:
+        # Fallback if any imports or database operations fail
+        return ProjectNameGenerator.generate()

--- a/server/app/utils/name_generator.py
+++ b/server/app/utils/name_generator.py
@@ -1,0 +1,61 @@
+"""
+Project name generator utility for creating human-readable project IDs.
+"""
+
+import random
+import string
+from typing import List
+
+
+class ProjectNameGenerator:
+    """Generates human-readable project names like 'rambling-tiger-d3ec'"""
+    
+    ADJECTIVES: List[str] = [
+        "rambling", "swift", "gentle", "mighty", "clever", "brave", "golden",
+        "silver", "crimson", "azure", "emerald", "violet", "amber", "serene", 
+        "fierce", "noble", "mystic", "ancient", "modern", "bright", "dark", 
+        "shining", "glowing", "dancing", "soaring", "flowing", "wild", "calm",
+        "bold", "quiet", "vivid", "subtle", "radiant", "graceful", "sturdy"
+    ]
+    
+    ANIMALS: List[str] = [
+        "tiger", "eagle", "wolf", "bear", "lion", "fox", "hawk", "owl",
+        "deer", "rabbit", "dolphin", "whale", "shark", "penguin", "falcon",
+        "raven", "swan", "turtle", "horse", "elephant", "leopard", "cheetah",
+        "jaguar", "panther", "lynx", "otter", "badger", "squirrel", "mongoose",
+        "crane", "salmon", "cobra", "viper", "gecko"
+    ]
+    
+    @classmethod
+    def generate(cls) -> str:
+        """Generate a readable project name in format: adjective-animal-suffix"""
+        adjective = random.choice(cls.ADJECTIVES)
+        animal = random.choice(cls.ANIMALS)
+        # Generate 4-character alphanumeric suffix (lowercase)
+        suffix = ''.join(random.choices(string.ascii_lowercase + string.digits, k=4))
+        return f"{adjective}-{animal}-{suffix}"
+def generate_unique_project_id(check_existence_func=None) -> str:
+    """
+    Generate a unique project ID, checking against existing IDs.
+    
+    Args:
+        check_existence_func: Function that takes an ID and returns True if it exists
+        
+    Returns:
+        A unique project ID string
+    """
+    max_attempts = 20
+    
+    for attempt in range(max_attempts):
+        project_id = ProjectNameGenerator.generate()
+        
+        # If no check function provided, return the generated ID
+        if check_existence_func is None:
+            return project_id
+            
+        # Check if ID already exists
+        if not check_existence_func(project_id):
+            return project_id
+    
+    # If we get here, we've exhausted our attempts
+    raise RuntimeError(f"Unable to generate unique project ID after {max_attempts} attempts")

--- a/server/app/utils/name_generator.py
+++ b/server/app/utils/name_generator.py
@@ -92,28 +92,6 @@ class ProjectNameGenerator:
         return f"{adjective}-{animal}-{suffix}"
 
 
-def generate_unique_project_id() -> str:
-    """Generate a unique project ID with database collision checking."""
-    # Importing here to avoid circular import issues
-    try:
-        from pynamodb.exceptions import DoesNotExist
-
-        from app.db.models import Project
-
-        max_attempts = 20
-        for _ in range(max_attempts):
-            project_id = ProjectNameGenerator.generate()
-            try:
-                # Try to get the project - if it exists, this won't raise an exception
-                Project.get(project_id)
-                # If we get here, project exists, try again
-                continue
-            except DoesNotExist:
-                # Project doesn't exist, this ID is unique
-                return project_id
-
-        # Fallback if all attempts failed
-        return ProjectNameGenerator.generate()
-    except Exception:
-        # Fallback if any imports or database operations fail
-        return ProjectNameGenerator.generate()
+def generate_project_id() -> str:
+    """Generate a project ID."""
+    return ProjectNameGenerator.generate()

--- a/server/app/utils/name_generator.py
+++ b/server/app/utils/name_generator.py
@@ -4,58 +4,127 @@ Project name generator utility for creating human-readable project IDs.
 
 import random
 import string
-from typing import List
+from collections.abc import Callable
+from typing import ClassVar
 
 
 class ProjectNameGenerator:
     """Generates human-readable project names like 'rambling-tiger-d3ec'"""
-    
-    ADJECTIVES: List[str] = [
-        "rambling", "swift", "gentle", "mighty", "clever", "brave", "golden",
-        "silver", "crimson", "azure", "emerald", "violet", "amber", "serene", 
-        "fierce", "noble", "mystic", "ancient", "modern", "bright", "dark", 
-        "shining", "glowing", "dancing", "soaring", "flowing", "wild", "calm",
-        "bold", "quiet", "vivid", "subtle", "radiant", "graceful", "sturdy"
+
+    ADJECTIVES: ClassVar[list[str]] = [
+        "rambling",
+        "swift",
+        "gentle",
+        "mighty",
+        "clever",
+        "brave",
+        "golden",
+        "silver",
+        "crimson",
+        "azure",
+        "emerald",
+        "violet",
+        "amber",
+        "serene",
+        "fierce",
+        "noble",
+        "mystic",
+        "ancient",
+        "modern",
+        "bright",
+        "dark",
+        "shining",
+        "glowing",
+        "dancing",
+        "soaring",
+        "flowing",
+        "wild",
+        "calm",
+        "bold",
+        "quiet",
+        "vivid",
+        "subtle",
+        "radiant",
+        "graceful",
+        "sturdy",
     ]
-    
-    ANIMALS: List[str] = [
-        "tiger", "eagle", "wolf", "bear", "lion", "fox", "hawk", "owl",
-        "deer", "rabbit", "dolphin", "whale", "shark", "penguin", "falcon",
-        "raven", "swan", "turtle", "horse", "elephant", "leopard", "cheetah",
-        "jaguar", "panther", "lynx", "otter", "badger", "squirrel", "mongoose",
-        "crane", "salmon", "cobra", "viper", "gecko"
+
+    ANIMALS: ClassVar[list[str]] = [
+        "tiger",
+        "eagle",
+        "wolf",
+        "bear",
+        "lion",
+        "fox",
+        "hawk",
+        "owl",
+        "deer",
+        "rabbit",
+        "dolphin",
+        "whale",
+        "shark",
+        "penguin",
+        "falcon",
+        "raven",
+        "swan",
+        "turtle",
+        "horse",
+        "elephant",
+        "leopard",
+        "cheetah",
+        "jaguar",
+        "panther",
+        "lynx",
+        "otter",
+        "badger",
+        "squirrel",
+        "mongoose",
+        "crane",
+        "salmon",
+        "cobra",
+        "viper",
+        "gecko",
     ]
-    
+
     @classmethod
     def generate(cls) -> str:
         """Generate a readable project name in format: adjective-animal-suffix"""
         adjective = random.choice(cls.ADJECTIVES)
         animal = random.choice(cls.ANIMALS)
         # Generate 4-character alphanumeric suffix (lowercase)
-        suffix = ''.join(random.choices(string.ascii_lowercase + string.digits, k=4))
+        suffix = "".join(random.choices(string.ascii_lowercase + string.digits, k=4))
         return f"{adjective}-{animal}-{suffix}"
-def generate_unique_project_id(check_existence_func=None) -> str:
+
+
+def generate_unique_project_id(
+    check_existence_func: Callable[[str], bool] | None = None,
+) -> str:
     """
     Generate a unique project ID, checking against existing IDs.
-    
+
     Args:
         check_existence_func: Function that takes an ID and returns True if it exists
-        
+
     Returns:
         A unique project ID string
+
+    Raises:
+        RuntimeError: If unable to generate unique ID after max attempts
     """
     max_attempts = 20
-    
-    for attempt in range(max_attempts):
+
+    for _ in range(max_attempts):
         project_id = ProjectNameGenerator.generate()
-        
+
         # If no check function provided, return the generated ID
         if check_existence_func is None:
             return project_id
-            
+
         # Check if ID already exists
         if not check_existence_func(project_id):
             return project_id
-    
+
     # If we get here, we've exhausted our attempts
-    raise RuntimeError(f"Unable to generate unique project ID after {max_attempts} attempts")
+    raise RuntimeError(
+        f"Unable to generate unique project ID after {max_attempts} attempts"
+    )

--- a/server/tests/test_name_generator.py
+++ b/server/tests/test_name_generator.py
@@ -1,0 +1,40 @@
+import re
+
+from app.utils.name_generator import ProjectNameGenerator, generate_project_id
+
+
+class TestProjectNameGenerator:
+    """Test the ProjectNameGenerator class."""
+
+    def test_generate_returns_correct_format(self):
+        """Test that generated names follow adjective-animal-suffix format."""
+        name = ProjectNameGenerator.generate()
+
+        # Should match pattern: word-word-4chars
+        pattern = r"^[a-z]+-[a-z]+-[a-z0-9]{4}$"
+        assert re.match(pattern, name), (
+            f"Generated name '{name}' doesn't match expected format"
+        )
+
+    def test_generate_uses_predefined_words(self):
+        """Test that generated names use words from the predefined lists."""
+        name = ProjectNameGenerator.generate()
+        adjective, animal, suffix = name.split("-")
+
+        assert adjective in ProjectNameGenerator.ADJECTIVES
+        assert animal in ProjectNameGenerator.ANIMALS
+        assert len(suffix) == 4
+
+    def test_generate_creates_unique_names(self):
+        """Test that multiple generations produce different names (usually)."""
+        names = {ProjectNameGenerator.generate() for _ in range(10)}
+
+        assert len(names) >= 8, "Expected mostly unique names from 10 generations"
+
+    def test_generate_project_id_function(self):
+        """Test the convenience function wrapper."""
+        project_id = generate_project_id()
+
+        # Should follow same format as the class method
+        pattern = r"^[a-z]+-[a-z]+-[a-z0-9]{4}$"
+        assert re.match(pattern, project_id)


### PR DESCRIPTION
- Add ProjectNameGenerator utility creating adjective-animal-suffix format
- Update Project model to use readable IDs instead of UUIDs
- Generated IDs like 'crimson-fox-o1au' improve user experience
- Collision-safe generation with uniqueness checking
- Improves project identification