### PR TITLE
fix: corrected access log level in deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -95,6 +95,7 @@ cat > /tmp/ftw-production.env << EOF
 PROCESSING__GPU=0
 SECURITY__AUTH_DISABLED=true
 LOGGING__LEVEL=INFO
+STORAGE__SOURCE_COOP__USE_STS_WORKAROUND=true
 EOF
 
 # Move environment file to proper location
@@ -114,7 +115,7 @@ HOME_DIR="$(eval echo ~$USER)"
 
 # Conditionally build the ExecStart command based on the GPU configuration.
 # We check the final destination of the production.env file.
-BASE_EXEC_START="${HOME_DIR}/.pixi/bin/pixi run --environment production python run.py --host 0.0.0.0 --port 8000 --no-access-log"
+BASE_EXEC_START="${HOME_DIR}/.pixi/bin/pixi run --environment production python run.py --host 0.0.0.0 --port 8000"
 EXEC_START_CMD=$BASE_EXEC_START
 
 if grep -q "PROCESSING__GPU=null" /etc/ftw-inference-api/production.env; then

--- a/server/app/core/config.py
+++ b/server/app/core/config.py
@@ -135,7 +135,7 @@ class SourceCoopConfig(BaseModel):
     secrets_manager_region: str | None = None
 
     # TEMPORARY: STS workaround (Remove when Source Coop is fixed)
-    use_sts_workaround: bool = False  # flag to enable/disable STS workaround
+    use_sts_workaround: bool = True  # flag to enable/disable STS workaround
     sts_role_arn: str = "arn:aws:iam::417712557820:role/ftw-cross-account-access"
     sts_external_id: str = "tge"
     sts_real_bucket: str = "us-west-2.opendata.source.coop"


### PR DESCRIPTION
Simple fix to the deployment scripts to account for the Source Coop STS workaround. 