### PR TITLE
feat: add scene selection route

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ The API provides the following versioned endpoints under `/v1/`:
 
 - `GET /`: Root endpoint that returns basic API information
 - `PUT /v1/example`: Compute field boundaries for a small area quickly and return as GeoJSON
+- `POST /v1/scene-selection`: Find optimal Sentinel-2 scenes for a specified area and time period
 - `POST /v1/projects`: Create a new project
 - `GET /v1/projects`: List all projects
 - `GET /v1/projects/{project_id}`: Get details of a specific project

--- a/pixi.lock
+++ b/pixi.lock
@@ -1768,6 +1768,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pendulum-3.1.0-py311h9e33e62_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.3.0-py311h1322bbf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.1.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pixi-pycharm-0.0.8-unix_hf108a03_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.8-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.2.0-pyha770c72_0.conda
@@ -2135,6 +2136,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pendulum-3.1.0-py311h3b9c2be_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.3.0-py311h25da234_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.1.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pixi-pycharm-0.0.8-unix_hf108a03_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.8-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.2.0-pyha770c72_0.conda
@@ -2485,6 +2487,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pendulum-3.1.0-py311h3ff9189_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.3.0-py311hb9ba9e9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.1.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pixi-pycharm-0.0.8-unix_hf108a03_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.8-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.2.0-pyha770c72_0.conda
@@ -2820,6 +2823,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pendulum-3.1.0-py311h533ab2d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.3.0-py311h0f9b5fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.1.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pixi-pycharm-0.0.8-win_hba80fca_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.8-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.2.0-pyha770c72_0.conda
@@ -3182,6 +3186,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pendulum-3.1.0-py311h9e33e62_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.3.0-py311h1322bbf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.1.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pixi-pycharm-0.0.9-unix_hf108a03_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.6.2-h0054346_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/prometheus-cpp-1.3.0-ha5d0236_0.conda
@@ -3527,6 +3532,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pendulum-3.1.0-py311h3b9c2be_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.3.0-py311h25da234_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.1.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pixi-pycharm-0.0.9-unix_hf108a03_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.6.2-h5273da6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/prometheus-cpp-1.3.0-h7802330_0.conda
@@ -3855,6 +3861,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pendulum-3.1.0-py311h3ff9189_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.3.0-py311hb9ba9e9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.1.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pixi-pycharm-0.0.9-unix_hf108a03_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.6.2-h1318a7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/prometheus-cpp-1.3.0-h0967b3e_0.conda
@@ -4168,6 +4175,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pendulum-3.1.0-py311h533ab2d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.3.0-py311h0f9b5fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.1.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pixi-pycharm-0.0.9-win_hba80fca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.6.2-h4f671f6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/propcache-0.3.1-py311h5082efb_0.conda
@@ -4519,6 +4527,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pendulum-3.1.0-py311h9e33e62_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.3.0-py311h1322bbf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.1.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pixi-pycharm-0.0.8-unix_hf108a03_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.6.2-h0054346_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/prometheus-cpp-1.3.0-ha5d0236_0.conda
@@ -4905,6 +4914,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pendulum-3.1.0-py311h3b9c2be_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-11.3.0-py311h25da234_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.1.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pixi-pycharm-0.0.8-unix_hf108a03_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.6.2-h5273da6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/prometheus-cpp-1.3.0-h7802330_0.conda
@@ -5274,6 +5284,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pendulum-3.1.0-py311h3ff9189_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.3.0-py311hb9ba9e9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.1.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pixi-pycharm-0.0.8-unix_hf108a03_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.6.2-h1318a7e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/prometheus-cpp-1.3.0-h0967b3e_0.conda
@@ -5627,6 +5638,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pendulum-3.1.0-py311h533ab2d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.3.0-py311h0f9b5fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.1.1-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pixi-pycharm-0.0.8-win_hba80fca_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.6.2-h4f671f6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/propcache-0.3.1-py311h5082efb_0.conda
@@ -15266,6 +15278,26 @@ packages:
   purls: []
   size: 6621
   timestamp: 1750158524827
+- conda: https://conda.anaconda.org/conda-forge/noarch/pixi-pycharm-0.0.9-unix_hf108a03_0.conda
+  sha256: adb49cb011bc758a18d7729431d393c96b1686e9cb8b2b0a76f158a20a590743
+  md5: 178205e98910428bf7411888adf63033
+  depends:
+  - __unix
+  - python >=3.8
+  license: BSD-3-Clause
+  purls: []
+  size: 6681
+  timestamp: 1758810290525
+- conda: https://conda.anaconda.org/conda-forge/noarch/pixi-pycharm-0.0.9-win_hba80fca_0.conda
+  sha256: 22c6fedb771249e8b9723a916a3dc558b74681d3d8c2f118667cba81851f2002
+  md5: de239ce0ba6c1b8d4bdd791650d8067c
+  depends:
+  - __win
+  - python >=3.8
+  license: BSD-3-Clause
+  purls: []
+  size: 6687
+  timestamp: 1758810287418
 - pypi: https://files.pythonhosted.org/packages/4f/7a/3965a2b58d172e106c1064af19707d29f86a0142c28ff40185490a0a8cfe/planetary_computer-1.0.0-py3-none-any.whl
   name: planetary-computer
   version: 1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ python-multipart = ">=0.0.6"
 requests = ">=2.28.0"
 pyyaml = ">=6.0"
 watchtower = ">=3.4.0"
+pixi-pycharm = ">=0.0.8,<0.0.10"
 
 [tool.pixi.pypi-dependencies]
 ftw-tools = ">=1.3.0"

--- a/server/app/api/v1/endpoints.py
+++ b/server/app/api/v1/endpoints.py
@@ -8,6 +8,7 @@ from app.schemas.requests import (
     ExampleWorkflowRequest,
     InferenceRequest,
     PolygonizationRequest,
+    SceneSelectionRequest,
 )
 from app.schemas.responses import (
     HealthResponse,
@@ -15,6 +16,7 @@ from app.schemas.responses import (
     ProjectsResponse,
     ProjectStatusResponse,
     RootResponse,
+    SceneSelectionResponse,
     TaskDetailsResponse,
     TaskSubmissionResponse,
 )
@@ -228,6 +230,21 @@ async def get_task_status(
     """Get detailed status and metadata for a specific task."""
     task_details = await task_service.get_task_details(project_id, task_id)
     return TaskDetailsResponse(**task_details)
+
+
+@router.post(
+    "/scene-selection",
+    response_model=SceneSelectionResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def scene_selection(
+    params: SceneSelectionRequest,
+    inference_service: InferenceServiceDep,
+    auth: AuthDep,
+) -> SceneSelectionResponse:
+    """Find optimal Sentinel-2 scenes for specified area and time."""
+    result = await inference_service.run_scene_selection(params.model_dump())
+    return SceneSelectionResponse(**result)
 
 
 @router.get("/health", response_model=HealthResponse, status_code=status.HTTP_200_OK)

--- a/server/app/ml/commands.py
+++ b/server/app/ml/commands.py
@@ -82,13 +82,15 @@ def build_scene_selection_command(
     out: str,
     cloud_cover_max: int = 20,
     buffer_days: int = 14,
+    stac_host: str = "mspc",
+    s2_collection: str = "c1",
 ) -> list[str]:
-    """Build ftw scene_selection command for Sentinel-2 scene selection."""
+    """Build ftw scene-selection command for Sentinel-2 scene selection."""
     bbox_str = ",".join(map(str, bbox))
     cmd = [
         "ftw",
         "inference",
-        "scene_selection",
+        "scene-selection",
         "--year",
         str(year),
         "--bbox",
@@ -97,6 +99,10 @@ def build_scene_selection_command(
         str(cloud_cover_max),
         "--buffer_days",
         str(buffer_days),
+        "--stac_host",
+        stac_host,
+        "--s2_collection",
+        s2_collection,
         "--out",
         out,
     ]

--- a/server/app/ml/commands.py
+++ b/server/app/ml/commands.py
@@ -74,3 +74,31 @@ def build_polygonize_command(
         cmd.append("--close_interiors")
 
     return cmd
+
+
+def build_scene_selection_command(
+    year: int,
+    bbox: list[float],
+    out: str,
+    cloud_cover_max: int = 20,
+    buffer_days: int = 14,
+) -> list[str]:
+    """Build ftw scene_selection command for Sentinel-2 scene selection."""
+    bbox_str = ",".join(map(str, bbox))
+    cmd = [
+        "ftw",
+        "inference",
+        "scene_selection",
+        "--year",
+        str(year),
+        "--bbox",
+        bbox_str,
+        "--cloud_cover_max",
+        str(cloud_cover_max),
+        "--buffer_days",
+        str(buffer_days),
+        "--out",
+        out,
+    ]
+
+    return cmd

--- a/server/app/ml/validation.py
+++ b/server/app/ml/validation.py
@@ -120,6 +120,39 @@ def validate_processing_params(params: dict[str, Any]) -> None:
         raise ValueError("Patch size must be a multiple of 32.")
 
 
+def validate_year(year: int) -> None:
+    """Validate year is within reasonable range for Sentinel-2 data."""
+    if year < 2015:
+        raise ValueError("Year must be 2015 or later (Sentinel-2 launch year)")
+    if year > 2030:
+        raise ValueError("Year must be 2030 or earlier")
+
+
+def validate_cloud_cover(cloud_cover: int) -> None:
+    """Validate cloud cover percentage is between 0-100."""
+    if cloud_cover < 0 or cloud_cover > 100:
+        raise ValueError("Cloud cover must be between 0 and 100 percent")
+
+
+def validate_buffer_days(buffer_days: int) -> None:
+    """Validate buffer days is reasonable positive integer."""
+    if buffer_days < 0:
+        raise ValueError("Buffer days must be 0 or positive")
+    if buffer_days > 365:
+        raise ValueError("Buffer days must be 365 or less")
+
+
+def prepare_scene_selection_params(params: dict[str, Any]) -> dict[str, Any]:
+    """Prepare and validate scene selection parameters."""
+    validate_bbox(params.get("bbox"), require_bbox=True)
+    year = params.get("year")
+    if year is not None:
+        validate_year(year)
+    validate_cloud_cover(params.get("cloud_cover_max", 20))
+    validate_buffer_days(params.get("buffer_days", 14))
+    return params
+
+
 def prepare_inference_params(
     params: dict[str, Any],
     require_bbox: bool = False,

--- a/server/app/ml/validation.py
+++ b/server/app/ml/validation.py
@@ -1,6 +1,7 @@
 """ML parameter validation functions."""
 
 import re
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -122,10 +123,11 @@ def validate_processing_params(params: dict[str, Any]) -> None:
 
 def validate_year(year: int) -> None:
     """Validate year is within reasonable range for Sentinel-2 data."""
+    current_year = datetime.now().year
     if year < 2015:
         raise ValueError("Year must be 2015 or later (Sentinel-2 launch year)")
-    if year > 2030:
-        raise ValueError("Year must be 2030 or earlier")
+    if year > current_year:
+        raise ValueError(f"Year must be {current_year} or earlier")
 
 
 def validate_cloud_cover(cloud_cover: int) -> None:

--- a/server/app/schemas/requests.py
+++ b/server/app/schemas/requests.py
@@ -71,14 +71,35 @@ class ExampleWorkflowRequest(BaseModel):
 class SceneSelectionRequest(BaseModel):
     """Parameters for Sentinel-2 scene selection."""
 
-    year: int = Field(..., description="Year for scene selection")
+    year: int = Field(
+        ..., description="Year for scene selection (2015 to current year)"
+    )
     bbox: list[float] = Field(
         ..., description="Bounding box [minX, minY, maxX, maxY] in EPSG:4326"
     )
     cloud_cover_max: int = Field(
-        20, description="Maximum cloud cover percentage (0-100)"
+        default=20,
+        ge=0,
+        le=100,
+        description="Maximum cloud cover percentage (0-100). Default: 20",
     )
-    buffer_days: int = Field(14, description="Buffer days around target date")
+    buffer_days: int = Field(
+        default=14,
+        ge=0,
+        le=365,
+        description="Buffer days around target date. Default: 14",
+    )
+    stac_host: Literal["mspc", "earthsearch"] = Field(
+        default="earthsearch",
+        description=(
+            "STAC API host to use. 'mspc' for Microsoft Planetary Computer, "
+            "'earthsearch' for Earth Search. Default: 'mspc'"
+        ),
+    )
+    s2_collection: str = Field(
+        default="c1",
+        description="Sentinel-2 collection version. Default: 'c1'",
+    )
 
 
 class CreateProjectRequest(BaseModel):

--- a/server/app/schemas/requests.py
+++ b/server/app/schemas/requests.py
@@ -68,6 +68,19 @@ class ExampleWorkflowRequest(BaseModel):
     )
 
 
+class SceneSelectionRequest(BaseModel):
+    """Parameters for Sentinel-2 scene selection."""
+
+    year: int = Field(..., description="Year for scene selection")
+    bbox: list[float] = Field(
+        ..., description="Bounding box [minX, minY, maxX, maxY] in EPSG:4326"
+    )
+    cloud_cover_max: int = Field(
+        20, description="Maximum cloud cover percentage (0-100)"
+    )
+    buffer_days: int = Field(14, description="Buffer days around target date")
+
+
 class CreateProjectRequest(BaseModel):
     """Request to create a new project."""
 

--- a/server/app/schemas/requests.py
+++ b/server/app/schemas/requests.py
@@ -93,7 +93,7 @@ class SceneSelectionRequest(BaseModel):
         default="earthsearch",
         description=(
             "STAC API host to use. 'mspc' for Microsoft Planetary Computer, "
-            "'earthsearch' for Earth Search. Default: 'mspc'"
+            "'earthsearch' for Earth Search. Default: 'earthsearch'"
         ),
     )
     s2_collection: str = Field(

--- a/server/app/schemas/responses.py
+++ b/server/app/schemas/responses.py
@@ -106,6 +106,13 @@ class InferenceResultsResponse(BaseModel):
     polygons: str | None = Field(None, description="URL to GeoJSON polygons result")
 
 
+class SceneSelectionResponse(BaseModel):
+    """Response for Sentinel-2 scene selection with HTTP URLs."""
+
+    window_a: str = Field(..., description="HTTP URL for window A scene")
+    window_b: str = Field(..., description="HTTP URL for window B scene")
+
+
 class HealthResponse(BaseModel):
     """Health check response."""
 

--- a/server/app/services/inference_service.py
+++ b/server/app/services/inference_service.py
@@ -63,10 +63,7 @@ class InferenceService:
             # Validate parameters
             validated_params = prepare_scene_selection_params(params)
 
-            async with temp_files_context() as temp_files:
-                # Create temporary output file
-                temp_output = temp_files.create_temp_file(suffix=".json")
-
+            async with temp_files_context("scene_selection.json") as (temp_output,):
                 # Build and execute CLI command
                 cmd = build_scene_selection_command(
                     year=validated_params["year"],

--- a/server/app/services/inference_service.py
+++ b/server/app/services/inference_service.py
@@ -20,6 +20,8 @@ from app.ml import (
     prepare_inference_params,
     run_polygonize,
 )
+from app.ml.commands import build_scene_selection_command
+from app.ml.validation import prepare_scene_selection_params
 from app.services.project_service import ProjectService
 from app.services.task_service import TaskService
 
@@ -54,6 +56,64 @@ class InferenceService:
         )
 
     # --- Public API: Workflow Submission ---
+
+    async def run_scene_selection(self, params: dict[str, Any]) -> dict[str, str]:
+        """Run scene selection to find optimal Sentinel-2 scenes."""
+        try:
+            # Validate parameters
+            validated_params = prepare_scene_selection_params(params)
+
+            async with temp_files_context() as temp_files:
+                # Create temporary output file
+                temp_output = temp_files.create_temp_file(suffix=".json")
+
+                # Build and execute CLI command
+                cmd = build_scene_selection_command(
+                    year=validated_params["year"],
+                    bbox=validated_params["bbox"],
+                    out=str(temp_output),
+                    cloud_cover_max=validated_params.get("cloud_cover_max", 20),
+                    buffer_days=validated_params.get("buffer_days", 14),
+                )
+
+                result = await run_async(cmd)
+                if result.returncode != 0:
+                    logger.error(f"Scene selection failed: {result.stderr}")
+                    raise RuntimeError("Scene selection command failed")
+
+                # Read and parse JSON output
+                async with aiofiles.open(temp_output) as f:
+                    content = await f.read()
+                    scene_data = json.loads(content)
+
+                # Convert S3 URLs to HTTP URLs
+                def s3_to_http(s3_url: str) -> str:
+                    """Convert s3://bucket/path to https://bucket.s3.amazonaws.com/path"""
+                    if s3_url.startswith("s3://"):
+                        # Remove s3:// prefix and split bucket from path
+                        s3_path = s3_url[5:]  # Remove "s3://"
+                        parts = s3_path.split("/", 1)
+                        if len(parts) == 2:
+                            bucket, path = parts
+                            return f"https://{bucket}.s3.amazonaws.com/{path}"
+                    return s3_url  # Return as-is if not S3 format
+
+                # Convert both windows to HTTP URLs
+                return {
+                    "window_a": s3_to_http(scene_data.get("window_a", "")),
+                    "window_b": s3_to_http(scene_data.get("window_b", "")),
+                }
+
+        except ValueError as e:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
+            ) from e
+        except Exception as e:
+            logger.error(f"Scene selection error: {e!s}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="An internal error occurred during scene selection",
+            ) from e
 
     async def run_example_workflow(
         self,

--- a/server/app/services/inference_service.py
+++ b/server/app/services/inference_service.py
@@ -71,6 +71,8 @@ class InferenceService:
                     out=str(temp_output),
                     cloud_cover_max=validated_params.get("cloud_cover_max", 20),
                     buffer_days=validated_params.get("buffer_days", 14),
+                    stac_host=validated_params.get("stac_host", "earthsearch"),
+                    s2_collection=validated_params.get("s2_collection", "c1"),
                 )
 
                 result = await run_async(cmd)

--- a/server/app/services/inference_service.py
+++ b/server/app/services/inference_service.py
@@ -58,7 +58,9 @@ class InferenceService:
     # --- Public API: Workflow Submission ---
 
     async def run_scene_selection(self, params: dict[str, Any]) -> dict[str, str]:
-        """Run scene selection to find optimal Sentinel-2 scenes."""
+        """Run scene selection to find optimal Sentinel-2 scenes.
+
+        Returns STAC item URLs that can be directly used with ftw download command."""
         try:
             # Validate parameters
             validated_params = prepare_scene_selection_params(params)
@@ -85,22 +87,10 @@ class InferenceService:
                     content = await f.read()
                     scene_data = json.loads(content)
 
-                # Convert S3 URLs to HTTP URLs
-                def s3_to_http(s3_url: str) -> str:
-                    """Convert s3://bucket/path to https://bucket.s3.amazonaws.com/path"""
-                    if s3_url.startswith("s3://"):
-                        # Remove s3:// prefix and split bucket from path
-                        s3_path = s3_url[5:]  # Remove "s3://"
-                        parts = s3_path.split("/", 1)
-                        if len(parts) == 2:
-                            bucket, path = parts
-                            return f"https://{bucket}.s3.amazonaws.com/{path}"
-                    return s3_url  # Return as-is if not S3 format
-
-                # Convert both windows to HTTP URLs
+                # Return STAC item URLs directly - ftw handles these natively
                 return {
-                    "window_a": s3_to_http(scene_data.get("window_a", "")),
-                    "window_b": s3_to_http(scene_data.get("window_b", "")),
+                    "window_a": scene_data.get("window_a", ""),
+                    "window_b": scene_data.get("window_b", ""),
                 }
 
         except ValueError as e:


### PR DESCRIPTION
### Summary

Adds a new `/v1/scene-selection` endpoint to find optimal Sentinel-2 satellite imagery for a given geographic area and time period.

Changes

- New API Endpoint: `POST /v1/scene-selection` that calls the ftw inference scene-selection CLI command
- Request Parameters:
  - Required: `year`, `bbox` (bounding box)
  - Optional: `cloud_cover_max` (default: 20), `buffer_days` (default: 14), `stac_host` (default: "earthsearch"), `s2_collection` (default: "c1")
- Response: Returns URLs for two Sentinel-2 scenes (window_a and window_b) converted from S3 to HTTPS format for direct browser access
- Validation: Dynamic year validation (2015 to current year), cloud cover (0-100%), buffer days (0-365)
- Docs: Updated README with new endpoint

Closes #12 and #32 