### PR TITLE
feat: dual area limits (500 km² example, 3000 km² batch)

### DIFF
--- a/server/app/core/config.py
+++ b/server/app/core/config.py
@@ -72,11 +72,22 @@ class SecurityConfig(BaseModel):
 class ProcessingConfig(BaseModel):
     """ML processing configuration."""
 
-    min_area_km2: float = 100.0
-    max_area_km2: float = 500.0
+    # Area limits for different processing modes
+    min_area_km2: float = 0.1
+    example_max_area_km2: float = 500.0  # Deprecated example endpoint
+    project_max_area_km2: float = 3000.0  # Project/batch processing
+    small_area_threshold_km2: float = 300.0
+
+    # Example endpoint deprecation
+    example_enabled: bool = False
+
     max_concurrent_examples: int = 10
     example_timeout: int = 60
     gpu: int | None = None
+
+    def get_max_area_for_mode(self, is_project: bool) -> float:
+        """Get maximum area limit based on processing mode."""
+        return self.project_max_area_km2 if is_project else self.example_max_area_km2
 
 
 class LoggingConfig(BaseModel):

--- a/server/app/ml/validation.py
+++ b/server/app/ml/validation.py
@@ -132,3 +132,50 @@ def prepare_inference_params(
     validate_model(params)
     validate_processing_params(params)
     return params
+
+
+def validate_bbox_area(
+    bbox: list[float],
+    is_project: bool,
+    settings: Any,
+) -> float:
+    """Validate bounding box area against limits.
+
+    Args:
+        bbox: [minX, minY, maxX, maxY]
+        is_project: True for project mode, False for example mode
+        settings: Application settings
+
+    Returns:
+        Area in square kilometers
+
+    Raises:
+        ValueError: If area is outside allowed limits
+    """
+    from app.core.geo import calculate_area_km2
+
+    area_km2 = calculate_area_km2(bbox)
+    min_area = settings.processing.min_area_km2
+    max_area = settings.processing.get_max_area_for_mode(is_project)
+
+    mode_name = "project/batch" if is_project else "example"
+
+    if area_km2 < min_area:
+        raise ValueError(
+            f"Area too small: {area_km2:.2f} sq km. Minimum area is {min_area} sq km."
+        )
+
+    if area_km2 > max_area:
+        suggestion = ""
+        if not is_project and area_km2 <= settings.processing.project_max_area_km2:
+            suggestion = (
+                f" Consider using project-based workflow which supports "
+                f"up to {settings.processing.project_max_area_km2} sq km."
+            )
+
+        raise ValueError(
+            f"Area too large for {mode_name} processing: {area_km2:.2f} sq km. "
+            f"Maximum area for {mode_name} mode is {max_area} sq km.{suggestion}"
+        )
+
+    return area_km2

--- a/server/app/schemas/responses.py
+++ b/server/app/schemas/responses.py
@@ -19,7 +19,9 @@ class RootResponse(BaseModel):
     title: str
     description: str
     min_area_km2: float
-    max_area_km2: float
+    example_max_area_km2: float
+    project_max_area_km2: float
+    example_endpoint_enabled: bool
     models: list[ModelInfo]
 
 

--- a/server/app/services/project_service.py
+++ b/server/app/services/project_service.py
@@ -435,14 +435,17 @@ class ProjectService:
         }
 
     def get_api_configuration(self) -> dict[str, Any]:
-        """Get API configuration for root endpoint."""
+        """Get API configuration information."""
         settings = get_settings()
+
         return {
             "api_version": settings.api.version,
             "title": settings.api.title,
             "description": settings.api.description,
             "min_area_km2": settings.processing.min_area_km2,
-            "max_area_km2": settings.processing.max_area_km2,
+            "example_max_area_km2": settings.processing.example_max_area_km2,
+            "project_max_area_km2": settings.processing.project_max_area_km2,
+            "example_endpoint_enabled": settings.processing.example_enabled,
             "models": settings.models,
         }
 

--- a/server/tests/test_area_limits.py
+++ b/server/tests/test_area_limits.py
@@ -1,0 +1,45 @@
+"""Tests for area limit validation."""
+
+import pytest
+from app.core.config import Settings
+from app.ml.validation import validate_bbox_area
+
+
+def test_validate_bbox_area_too_small():
+    """Should reject areas smaller than 0.1 km²."""
+    # Tiny box near the equator (~0.012 km²)
+    bbox = [0.0, 0.0, 0.001, 0.001]
+    with pytest.raises(ValueError, match="Minimum area is 0.1"):
+        validate_bbox_area(bbox, is_project=True, settings=Settings())
+
+
+def test_validate_bbox_area_example_valid():
+    """Should accept a small example area under 500 km²."""
+    # ~200 km² near 45° lat (0.15 x 0.15 degrees)
+    bbox = [10.0, 45.0, 10.15, 45.15]
+    area = validate_bbox_area(bbox, is_project=False, settings=Settings())
+    assert 150 < area < 250
+
+
+def test_validate_bbox_area_example_too_large():
+    """Should reject example areas over 500 km²."""
+    # ~8,600 km² near 45° lat (1.0 x 1.0 degrees)
+    bbox = [10.0, 45.0, 11.0, 46.0]
+    with pytest.raises(ValueError, match="Area too large.*example"):
+        validate_bbox_area(bbox, is_project=False, settings=Settings())
+
+
+def test_validate_bbox_area_project_valid():
+    """Should accept a batch/project area under 3000 km²."""
+    # ~2,000 km² near 45° lat (0.5 x 0.5 degrees)
+    bbox = [10.0, 45.0, 10.5, 45.5]
+    area = validate_bbox_area(bbox, is_project=True, settings=Settings())
+    assert 1500 < area < 2500
+
+
+def test_validate_bbox_area_project_too_large():
+    """Should reject project areas over 3000 km²."""
+    # ~35,000 km² near 45° lat (2.0 x 2.0 degrees)
+    bbox = [10.0, 45.0, 12.0, 47.0]
+    with pytest.raises(ValueError, match="Area too large.*project"):
+        validate_bbox_area(bbox, is_project=True, settings=Settings())


### PR DESCRIPTION
- Add config values for example/project area limit
- Expose both in root API response
- Add validation for bbox area
- Update project service to surface new config
- Add tests for min, example, and project limits