### PR TITLE
Add feedback and contribution endpoints to OpenAPI spec

### DIFF
--- a/specification/openapi.yaml
+++ b/specification/openapi.yaml
@@ -443,6 +443,123 @@ paths:
           $ref: '#/components/responses/4XX'
         5XX:
           $ref: '#/components/responses/5XX'
+
+  # ===========================================================================
+  # Feedback & Contribution Endpoints (unauthenticated — no bearer token)
+  # ===========================================================================
+  /feedback/tile-rating:
+    post:
+      tags:
+        - Feedback
+      summary: Submit a tile quality rating
+      operationId: submitTileRating
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TileRatingRequest'
+      responses:
+        '200':
+          description: Rating submitted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TileRatingResponse'
+        4XX:
+          $ref: '#/components/responses/4XX'
+        429:
+          $ref: '#/components/responses/429'
+        5XX:
+          $ref: '#/components/responses/5XX'
+
+  /feedback/tell-us-more:
+    post:
+      tags:
+        - Feedback
+      summary: Submit detailed feedback
+      operationId: submitDetailedFeedback
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TellUsMoreRequest'
+      responses:
+        '200':
+          description: Feedback submitted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TellUsMoreResponse'
+        403:
+          $ref: '#/components/responses/CaptchaFailed'
+        4XX:
+          $ref: '#/components/responses/4XX'
+        429:
+          $ref: '#/components/responses/429'
+        5XX:
+          $ref: '#/components/responses/5XX'
+
+  /feedback/contribute:
+    post:
+      tags:
+        - Feedback
+      summary: Submit a contribution interest form
+      operationId: submitContribution
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ContributeRequest'
+      responses:
+        '200':
+          description: Contribution form submitted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContributeResponse'
+        403:
+          $ref: '#/components/responses/CaptchaFailed'
+        4XX:
+          $ref: '#/components/responses/4XX'
+        429:
+          $ref: '#/components/responses/429'
+        5XX:
+          $ref: '#/components/responses/5XX'
+
+  /feedback/tile-summary/{tile_id}:
+    get:
+      tags:
+        - Feedback
+      summary: Get aggregated ratings for a tile
+      operationId: getTileSummary
+      parameters:
+        - name: tile_id
+          in: path
+          required: true
+          schema:
+            type: string
+            maxLength: 100
+      responses:
+        '200':
+          description: Tile rating summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TileSummaryResponse'
+        '404':
+          description: No ratings found for this tile
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        429:
+          $ref: '#/components/responses/429'
+        5XX:
+          $ref: '#/components/responses/5XX'
+
 components:
   parameters:
     project_id:
@@ -468,6 +585,18 @@ components:
             $ref: '#/components/schemas/Error'
     5XX:
       description: Server error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    429:
+      description: Rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    CaptchaFailed:
+      description: Captcha verification failed
       content:
         application/json:
           schema:
@@ -764,6 +893,207 @@ components:
           type: string
           nullable: true
           description: Error message if task failed
+
+    # =========================================================================
+    # Feedback & Contribution Schemas
+    # =========================================================================
+    TileRatingRequest:
+      type: object
+      required:
+        - tile_id
+        - rating
+        - session_id
+      properties:
+        tile_id:
+          type: string
+          minLength: 1
+          maxLength: 100
+        rating:
+          type: integer
+          enum: [1, 2, 3]
+          description: "1: Not Great, 2: Ok, 3: Great!"
+        session_id:
+          type: string
+          format: uuid
+        map_center_lat:
+          type: number
+          minimum: -90
+          maximum: 90
+        map_center_lng:
+          type: number
+          minimum: -180
+          maximum: 180
+        map_zoom:
+          type: integer
+          minimum: 0
+          maximum: 22
+
+    TileRatingResponse:
+      type: object
+      required:
+        - rating_id
+        - status
+      properties:
+        rating_id:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: [created, updated]
+
+    TellUsMoreRequest:
+      type: object
+      required:
+        - tile_id
+        - quality_feedback
+        - use_case
+        - session_id
+        - captcha_token
+      properties:
+        tile_id:
+          type: string
+          minLength: 1
+          maxLength: 100
+        rating:
+          type: integer
+          enum: [1, 2, 3]
+        quality_feedback:
+          type: string
+          minLength: 1
+          maxLength: 5000
+        use_case:
+          type: string
+          minLength: 1
+          maxLength: 2000
+        name:
+          type: string
+          maxLength: 200
+        email:
+          type: string
+          format: email
+          maxLength: 254
+        organization:
+          type: string
+          maxLength: 200
+        session_id:
+          type: string
+          format: uuid
+        map_center_lat:
+          type: number
+          minimum: -90
+          maximum: 90
+        map_center_lng:
+          type: number
+          minimum: -180
+          maximum: 180
+        map_zoom:
+          type: integer
+          minimum: 0
+          maximum: 22
+        captcha_token:
+          type: string
+          minLength: 1
+
+    TellUsMoreResponse:
+      type: object
+      required:
+        - feedback_id
+        - status
+      properties:
+        feedback_id:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: [submitted]
+
+    ContributeRequest:
+      type: object
+      required:
+        - contribution_types
+        - name
+        - email
+        - session_id
+        - captcha_token
+      properties:
+        contribution_types:
+          type: array
+          items:
+            type: string
+            enum:
+              - annotator
+              - share_data
+              - provide_models
+              - contribute_code
+          minItems: 1
+          uniqueItems: true
+        resource_link:
+          type: string
+          maxLength: 1000
+        additional_info:
+          type: string
+          maxLength: 5000
+        name:
+          type: string
+          minLength: 1
+          maxLength: 200
+        email:
+          type: string
+          format: email
+          maxLength: 254
+        organization:
+          type: string
+          maxLength: 200
+        session_id:
+          type: string
+          format: uuid
+        captcha_token:
+          type: string
+          minLength: 1
+
+    ContributeResponse:
+      type: object
+      required:
+        - contribution_id
+        - status
+      properties:
+        contribution_id:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: [submitted]
+
+    TileSummaryResponse:
+      type: object
+      required:
+        - tile_id
+        - total_ratings
+        - average_rating
+        - rating_distribution
+      properties:
+        tile_id:
+          type: string
+        total_ratings:
+          type: integer
+          minimum: 0
+        average_rating:
+          type: number
+          minimum: 1
+          maximum: 3
+        rating_distribution:
+          type: object
+          properties:
+            "1":
+              type: integer
+              minimum: 0
+            "2":
+              type: integer
+              minimum: 0
+            "3":
+              type: integer
+              minimum: 0
+
   securitySchemes:
     bearer:
       description: Bearer token


### PR DESCRIPTION
Add Feedback & Contribution API Endpoints

Add four new unauthenticated endpoints under /feedback/ to specification/openapi.yaml to support user feedback and community contribution forms for the global field boundaries release.
All existing endpoints, schemas, and security are unchanged. The new endpoints are appended after the existing paths and schemas. 

Paths added:POST  -  /feedback/tile-rating
POST  -  /feedback/tell-us-more
POST  -  /feedback/contribute
GET  -  /feedback/tile-summary/{tile_id}
Authentication
These endpoints are unauthenticated. No bearer token required. Spam prevention is handled via browser-generated session_id, captcha (Cloudflare Turnstile) on the detailed forms, and IP rate limiting.

Schemas: TileRatingRequest, TileRatingResponse, TellUsMoreRequest, TellUsMoreResponse, ContributeRequest, ContributeResponse, TileSummaryResponse

Forms
Tile Rating: Quick 1-3 rating on a map tile (to be defined by current view area). No captcha. Dedup via upsert on tile_id + session_id.
Tell Us More: Detailed feedback (quality assessment, use case, optional contact info). Requires captcha. Triggers email notification.
Contribute: Community contribution interest (annotator, share data, provide models, contribute code). Requires captcha. Triggers email notification.

Implementation requirements
Storage: Three new DynamoDB tables (ftw_tile_ratings, ftw_detailed_feedback, ftw_contributions)
Email: AWS SNS topic for notifications on "Tell Us More" and "Contribute" submissions
Captcha: Cloudflare Turnstile server-side verification
Rate limiting: slowapi — 30 per min for tile rating, 5 per min for detailed forms, 60 per min for tile summary
Dependencies: boto3, httpx, slowapi, pydantic[email]

Open items
tile_id format TBD — accepted as opaque string (max 100 chars)
Turnstile site key + secret key: pending setup
SNS topic ARN: needs creation in AWS
Notification recipient email: TBD