### PR TITLE
Add feedback and contribution API endpoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,3 +129,5 @@ exclude_lines = [
 [tool.coverage.xml]
 output = "coverage.xml"
 
+[tool.uv]
+no-build-isolation-package = ["flatdict"]

--- a/server/app/api/v1/__init__.py
+++ b/server/app/api/v1/__init__.py
@@ -1,3 +1,11 @@
-from .endpoints import router
+from fastapi import APIRouter
+
+from .endpoints import router as _endpoints_router
+from .feedback import feedback_router
+
+# Combine all v1 routers so main.py requires no changes.
+router = APIRouter()
+router.include_router(_endpoints_router)
+router.include_router(feedback_router)
 
 __all__ = ["router"]

--- a/server/app/api/v1/dependencies.py
+++ b/server/app/api/v1/dependencies.py
@@ -1,10 +1,11 @@
 from typing import Annotated, cast
 
-from fastapi import Depends, Request
+from fastapi import Depends, HTTPException, Query, Request, status
 
 from app.core.auth import verify_auth
 from app.core.queue import QueueBackend
 from app.core.storage import StorageBackend
+from app.ml.validation import validate_bbox
 from app.services.inference_service import InferenceService
 from app.services.project_service import ProjectService
 from app.services.task_service import TaskService
@@ -50,3 +51,30 @@ InferenceServiceDep = Annotated[
 ]
 ProjectServiceDep = Annotated[ProjectService, Depends(get_project_service)]
 TaskServiceDep = Annotated[TaskService, Depends(get_task_service)]
+
+
+def parse_bbox_query(
+    bbox: Annotated[
+        str,
+        Query(
+            description=(
+                "WGS84 bounding box as a comma-separated string in the order "
+                "minLng,minLat,maxLng,maxLat (e.g. 12.0,48.0,13.0,49.0)"
+            ),
+            pattern=r"^-?\d+(\.\d+)?,-?\d+(\.\d+)?,-?\d+(\.\d+)?,-?\d+(\.\d+)?$",
+        ),
+    ],
+) -> list[float]:
+    """Parse and validate a bbox query parameter into a list of four floats."""
+    values = [float(x) for x in bbox.split(",")]
+    try:
+        validate_bbox(values)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
+    return values
+
+
+BBoxQueryDep = Annotated[list[float], Depends(parse_bbox_query)]

--- a/server/app/api/v1/feedback.py
+++ b/server/app/api/v1/feedback.py
@@ -1,0 +1,222 @@
+import json
+
+from fastapi import APIRouter, HTTPException, status
+from pynamodb.exceptions import PutError, ScanError
+
+from app.api.v1.dependencies import AuthDep, BBoxQueryDep
+from app.core.logging import get_logger
+from app.db.models import FeedbackRecord
+from app.schemas.feedback import (
+    AreaSummaryResponse,
+    ContributeRequest,
+    ContributeResponse,
+    TellUsMoreRequest,
+    TellUsMoreResponse,
+    TileRatingRequest,
+    TileRatingResponse,
+)
+
+logger = get_logger(__name__)
+
+feedback_router = APIRouter(prefix="/feedback", tags=["Feedback"])
+
+
+def _bboxes_intersect(a: list[float], b: list[float]) -> bool:
+    """Return True if two WGS84 bboxes intersect."""
+    a_min_lng, a_min_lat, a_max_lng, a_max_lat = a
+    b_min_lng, b_min_lat, b_max_lng, b_max_lat = b
+    return (
+        a_min_lng <= b_max_lng
+        and a_max_lng >= b_min_lng
+        and a_min_lat <= b_max_lat
+        and a_max_lat >= b_min_lat
+    )
+
+
+@feedback_router.post(
+    "/tile-rating",
+    status_code=status.HTTP_200_OK,
+)
+async def submit_tile_rating(
+    body: TileRatingRequest,
+    auth: AuthDep,
+) -> TileRatingResponse:
+    """Submit a 1-3 quality rating for the field boundaries visible in the current
+    viewport.
+
+    **Location:** Identified by the WGS84 viewport bbox plus zoom level.
+
+    **Deduplication:** If the same client submits multiple ratings for substantially
+    the same bbox + zoom within a short window, the server treats the latest as an
+    update. Response status will be `updated` in that case.
+
+    **Rate limit:** 30 requests per minute per IP.
+    """
+    record = FeedbackRecord(
+        feedback_type="tile_rating",
+        bbox=json.dumps(body.bbox),
+        resolution=body.resolution,
+        payload=json.dumps(body.model_dump()),
+    )
+    try:
+        record.save()
+    except PutError:
+        logger.error(
+            "Failed to save tile_rating record",
+            exc_info=True,
+            extra={"feedback_type": "tile_rating"},
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Feedback could not be saved. Please try again.",
+        ) from None
+    logger.info("tile_rating saved", extra={"rating_id": record.id})
+    # TODO: implement IP-based deduplication — if same IP submits for the same
+    # bbox+zoom within a short window, update the existing record and return
+    # status="updated" instead of creating a new one.
+    return TileRatingResponse(rating_id=record.id, status="created")
+
+
+@feedback_router.post(
+    "/tell-us-more",
+    status_code=status.HTTP_200_OK,
+)
+async def submit_tell_us_more(
+    body: TellUsMoreRequest,
+    auth: AuthDep,
+) -> TellUsMoreResponse:
+    """Submit detailed feedback about field boundary quality.
+
+    Typically reached via a "Tell Us More" button after a quick tile rating.
+
+    **Rate limit:** 5 requests per minute per IP.
+
+    **Email notification:** Each successful submission will trigger an email
+    notification to project maintainers (SNS integration pending).
+    """
+    record = FeedbackRecord(
+        feedback_type="tell_us_more",
+        bbox=json.dumps(body.bbox),
+        resolution=body.resolution,
+        payload=json.dumps(body.model_dump()),
+    )
+    try:
+        record.save()
+    except PutError:
+        logger.error(
+            "Failed to save tell_us_more record",
+            exc_info=True,
+            extra={"feedback_type": "tell_us_more"},
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Feedback could not be saved. Please try again.",
+        ) from None
+    logger.info("tell_us_more feedback saved", extra={"feedback_id": record.id})
+    # TODO: trigger SNS notification to project maintainers
+    return TellUsMoreResponse(feedback_id=record.id, status="submitted")
+
+
+@feedback_router.post(
+    "/contribute",
+    status_code=status.HTTP_200_OK,
+)
+async def submit_contribute(
+    body: ContributeRequest,
+    auth: AuthDep,
+) -> ContributeResponse:
+    """Submit a community contribution interest form.
+
+    Captures interest from annotators, data providers, model developers, and
+    code contributors.
+
+    **Rate limit:** 5 requests per minute per IP.
+
+    **Email notification:** Each successful submission will trigger an email
+    notification to project maintainers (SNS integration pending).
+    """
+    record = FeedbackRecord(
+        feedback_type="contribute",
+        payload=json.dumps(body.model_dump()),
+    )
+    try:
+        record.save()
+    except PutError:
+        logger.error(
+            "Failed to save contribute record",
+            exc_info=True,
+            extra={"feedback_type": "contribute"},
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Feedback could not be saved. Please try again.",
+        ) from None
+    logger.info("contribution form saved", extra={"contribution_id": record.id})
+    # TODO: trigger SNS notification to project maintainers
+    return ContributeResponse(contribution_id=record.id, status="submitted")
+
+
+@feedback_router.get(
+    "/area-summary",
+    status_code=status.HTTP_200_OK,
+    responses={
+        404: {"description": "No ratings found in this area"},
+    },
+)
+async def get_area_summary(
+    auth: AuthDep,
+    bbox: BBoxQueryDep,
+) -> AreaSummaryResponse:
+    """Return aggregate rating statistics for all tile ratings whose viewport
+    bbox intersects the requested bbox.
+
+    Used by the frontend to highlight regions where users have provided feedback.
+
+    **Rate limit:** 60 requests per minute per IP.
+    """
+    matching_ratings: list[int] = []
+
+    try:
+        scan_results = list(
+            FeedbackRecord.scan(FeedbackRecord.feedback_type == "tile_rating")
+        )
+    except ScanError:
+        logger.error("DynamoDB scan failed in get_area_summary", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Area summary is temporarily unavailable.",
+        ) from None
+
+    for record in scan_results:
+        if not record.bbox:
+            continue
+        try:
+            record_bbox: list[float] = json.loads(record.bbox)
+            record_payload: dict = json.loads(record.payload)
+        except (json.JSONDecodeError, ValueError):
+            continue
+
+        if _bboxes_intersect(bbox, record_bbox):
+            rating = record_payload.get("rating")
+            if isinstance(rating, int) and rating in (1, 2, 3):
+                matching_ratings.append(rating)
+
+    if not matching_ratings:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No ratings found in this area",
+        )
+
+    total = len(matching_ratings)
+    avg = round(sum(matching_ratings) / total, 2)
+
+    return AreaSummaryResponse(
+        bbox=bbox,
+        total_ratings=total,
+        average_rating=avg,
+        rating_distribution=[
+            {"level": 1, "count": matching_ratings.count(1)},
+            {"level": 2, "count": matching_ratings.count(2)},
+            {"level": 3, "count": matching_ratings.count(3)},
+        ],
+    )

--- a/server/app/db/database.py
+++ b/server/app/db/database.py
@@ -1,6 +1,6 @@
-from app.db.models import Image, InferenceResult, Project
+from app.db.models import FeedbackRecord, Image, InferenceResult, Project
 
-TABLES = (Image, InferenceResult, Project)
+TABLES = (Image, InferenceResult, Project, FeedbackRecord)
 LOCAL_CAPACITY = 1
 
 

--- a/server/app/db/models.py
+++ b/server/app/db/models.py
@@ -1,10 +1,10 @@
 import json
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any, cast
 
 import pendulum
-from pynamodb.attributes import UnicodeAttribute, UTCDateTimeAttribute
+from pynamodb.attributes import NumberAttribute, UnicodeAttribute, UTCDateTimeAttribute
 from pynamodb.models import Model
 
 from app.core.config import get_settings
@@ -97,3 +97,33 @@ class InferenceResult(Model):
             cls.scan((cls.project_id == project_id) & (cls.result_type == result_type))
         )
         return max(results, key=lambda x: x.created_at) if results else None
+
+
+class FeedbackRecord(Model):
+    """Stores all user feedback and contribution submissions in a single table.
+
+    feedback_type values:
+      - 'tile_rating'  : quick 1-3 viewport rating
+      - 'tell_us_more' : detailed quality feedback form
+      - 'contribute'   : community contribution interest form
+
+    bbox and resolution are only populated for tile_rating and tell_us_more records.
+    payload stores the full serialised request body as a JSON string.
+    """
+
+    class Meta:
+        table_name = f"{settings.dynamodb.table_prefix}feedback"
+        region = settings.dynamodb.aws_region
+        host = settings.dynamodb.dynamodb_endpoint
+
+    id = UnicodeAttribute(hash_key=True, default_for_new=lambda: str(uuid.uuid4()))
+    feedback_type = UnicodeAttribute()  # 'tile_rating' | 'tell_us_more' | 'contribute'
+    created_at = UTCDateTimeAttribute(default_for_new=lambda: datetime.now(UTC))
+    bbox = UnicodeAttribute(
+        null=True
+    )  # JSON "[minLng,minLat,maxLng,maxLat]" — omitted for contribute
+    resolution = NumberAttribute(
+        null=True
+    )  # pixel resolution in metres — omitted for contribute
+    source_ip = UnicodeAttribute(null=True)  # client IP for future dedup
+    payload = UnicodeAttribute(default="{}")  # full JSON of the request body

--- a/server/app/schemas/feedback.py
+++ b/server/app/schemas/feedback.py
@@ -1,0 +1,207 @@
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class TileRatingRequest(BaseModel):
+    """Request body for the tile-rating endpoint."""
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    rating: Literal[1, 2, 3] = Field(
+        ..., description="Quality rating: 1=Not Great, 2=Ok, 3=Great!"
+    )
+    bbox: list[float] = Field(
+        ...,
+        min_length=4,
+        max_length=4,
+        description="WGS84 viewport bbox [minLng, minLat, maxLng, maxLat]",
+    )
+    resolution: float = Field(
+        ...,
+        ge=0,
+        description=(
+            "Pixel resolution in meters at time of rating. "
+            "Indicates how closely the user was inspecting the data."
+        ),
+    )
+
+    @field_validator("bbox")
+    @classmethod
+    def validate_bbox(cls, v: list[float]) -> list[float]:
+        min_lng, min_lat, max_lng, max_lat = v
+        if min_lng > max_lng:
+            raise ValueError("bbox minLng must be <= maxLng")
+        if min_lat > max_lat:
+            raise ValueError("bbox minLat must be <= maxLat")
+        return v
+
+
+class TileRatingResponse(BaseModel):
+    """Response for the tile-rating endpoint."""
+
+    rating_id: str = Field(..., description="UUID of the stored rating record")
+    status: Literal["created", "updated"] = Field(
+        ...,
+        description=(
+            "'created' if a new record was stored, "
+            "'updated' if dedup logic was applied to an existing record"
+        ),
+    )
+
+
+class TellUsMoreRequest(BaseModel):
+    """Request body for the tell-us-more endpoint."""
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    quality_feedback: str = Field(
+        ...,
+        min_length=1,
+        max_length=5000,
+        description="What was good or bad, and how must field boundaries improve?",
+    )
+    use_case: str = Field(
+        ...,
+        min_length=1,
+        max_length=2000,
+        description="How would you use field boundaries? Describe your use case.",
+    )
+    bbox: list[float] = Field(
+        ...,
+        min_length=4,
+        max_length=4,
+        description="WGS84 viewport bbox [minLng, minLat, maxLng, maxLat]",
+    )
+    resolution: float = Field(
+        ...,
+        ge=0,
+        description=(
+            "Pixel resolution in meters at time of submission. "
+            "Indicates how closely the user was inspecting the data."
+        ),
+    )
+    rating: Literal[1, 2, 3] | None = Field(
+        default=None,
+        description="Optional rating carried over from the tile-rating form",
+    )
+    name: str | None = Field(
+        default=None, max_length=200, description="Optional submitter name"
+    )
+    email: str | None = Field(
+        default=None, max_length=254, description="Optional submitter email address"
+    )
+    organization: str | None = Field(
+        default=None, max_length=200, description="Optional submitter organization"
+    )
+
+    @field_validator("bbox")
+    @classmethod
+    def validate_bbox(cls, v: list[float]) -> list[float]:
+        min_lng, min_lat, max_lng, max_lat = v
+        if min_lng > max_lng:
+            raise ValueError("bbox minLng must be <= maxLng")
+        if min_lat > max_lat:
+            raise ValueError("bbox minLat must be <= maxLat")
+        return v
+
+    @field_validator("email")
+    @classmethod
+    def validate_email_format(cls, v: str | None) -> str | None:
+        if v is not None and "@" not in v:
+            raise ValueError("Invalid email address")
+        return v
+
+
+class TellUsMoreResponse(BaseModel):
+    """Response for the tell-us-more endpoint."""
+
+    feedback_id: str = Field(..., description="UUID of the stored feedback record")
+    status: Literal["submitted"]
+
+
+class ContributeRequest(BaseModel):
+    """Request body for the contribute endpoint."""
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    contribution_types: list[
+        Literal["annotator", "share_data", "provide_models", "contribute_code"]
+    ] = Field(
+        ...,
+        min_length=1,
+        description=(
+            "One or more ways the submitter would like to contribute: "
+            "'annotator', 'share_data', 'provide_models', 'contribute_code'"
+        ),
+    )
+    name: str = Field(
+        ..., min_length=1, max_length=200, description="Required submitter name"
+    )
+    email: str = Field(
+        ..., max_length=254, description="Required submitter email address"
+    )
+    resources: str | None = Field(
+        default=None,
+        max_length=5000,
+        description=(
+            "Resources (field boundaries, models, etc.) the user wants to share — "
+            "for example, a dataset URL or model repository with a description."
+        ),
+    )
+    additional_info: str | None = Field(
+        default=None,
+        max_length=5000,
+        description="Anything else the submitter wants to share",
+    )
+    organization: str | None = Field(
+        default=None, max_length=200, description="Optional submitter organization"
+    )
+
+    @field_validator("contribution_types")
+    @classmethod
+    def validate_unique_types(cls, v: list[str]) -> list[str]:
+        if len(v) != len(set(v)):
+            raise ValueError("contribution_types must not contain duplicates")
+        return v
+
+    @field_validator("email")
+    @classmethod
+    def validate_email_format(cls, v: str) -> str:
+        if "@" not in v:
+            raise ValueError("Invalid email address")
+        return v
+
+
+class ContributeResponse(BaseModel):
+    """Response for the contribute endpoint."""
+
+    contribution_id: str = Field(
+        ..., description="UUID of the stored contribution record"
+    )
+    status: Literal["submitted"]
+
+
+class AreaSummaryResponse(BaseModel):
+    """Response for the area-summary endpoint."""
+
+    bbox: list[float] = Field(
+        ..., description="The requested WGS84 bbox [minLng, minLat, maxLng, maxLat]"
+    )
+    total_ratings: int = Field(
+        ..., ge=0, description="Total ratings whose viewport intersects this bbox"
+    )
+    average_rating: float = Field(
+        ...,
+        ge=1.0,
+        le=3.0,
+        description="Average rating across all matching submissions",
+    )
+    rating_distribution: list[dict[str, int]] = Field(
+        ...,
+        description=(
+            "Count of ratings for each value: "
+            '[{"level": 1, "count": n}, {"level": 2, "count": n}, '
+            '{"level": 3, "count": n}]'
+        ),
+    )

--- a/server/app/services/inference_service.py
+++ b/server/app/services/inference_service.py
@@ -1,7 +1,6 @@
 import json
 import time
 import uuid
-from pathlib import Path
 from typing import Any
 
 import aiofiles
@@ -335,45 +334,50 @@ class InferenceService:
     ) -> str | dict[str, Any]:
         """Run ML pipeline for example workflow with conditional polygonization."""
         uid = str(uuid.uuid4())
-        temp_dir = Path("data/temp")
-        image_file = temp_dir / f"{uid}.tif"
+        ext = "ndjson" if ndjson else "json"
 
-        bbox = inference_params["bbox"]
-        images = inference_params["images"]
+        async with temp_files_context(
+            f"{uid}.tif",
+            f"{uid}.geojson",
+            f"{uid}.inference.tif",
+            f"{uid}.{ext}",
+        ) as (image_file, output_file, inference_file, polygon_file):
+            bbox = inference_params["bbox"]
+            images = inference_params["images"]
 
-        model_spec = MODEL_REGISTRY.get(inference_params["model"])
-        is_instance_segmentation = (
-            model_spec.instance_segmentation if model_spec else False
-        )
-        requires_polygonization = model_spec.requires_polygonize if model_spec else True
+            model_spec = MODEL_REGISTRY.get(inference_params["model"])
+            is_instance_segmentation = (
+                model_spec.instance_segmentation if model_spec else False
+            )
+            requires_polygonization = (
+                model_spec.requires_polygonize if model_spec else True
+            )
 
-        if model_spec and not model_spec.requires_window:
-            win_a = images[0]
-            win_b = None
-        else:
-            win_a = images[0]
-            win_b = images[1] if len(images) > 1 else None
+            if model_spec and not model_spec.requires_window:
+                win_a = images[0]
+                win_b = None
+            else:
+                win_a = images[0]
+                win_b = images[1] if len(images) > 1 else None
 
-        context = {
-            "ml_metrics": {
-                "processing_stage": "pipeline_start",
-                "bounding_box": {
-                    "min_lon": bbox[0],
-                    "min_lat": bbox[1],
-                    "max_lon": bbox[2],
-                    "max_lat": bbox[3],
-                },
-                "bbox_area_km2": calculate_area_km2(bbox),
-                "image_urls": [win_a] if win_b is None else [win_a, win_b],
-                "model_path": inference_params.get("model", "unknown"),
-                "gpu_enabled": gpu is not None,
+            context = {
+                "ml_metrics": {
+                    "processing_stage": "pipeline_start",
+                    "bounding_box": {
+                        "min_lon": bbox[0],
+                        "min_lat": bbox[1],
+                        "max_lon": bbox[2],
+                        "max_lat": bbox[3],
+                    },
+                    "bbox_area_km2": calculate_area_km2(bbox),
+                    "image_urls": [win_a] if win_b is None else [win_a, win_b],
+                    "model_path": inference_params.get("model", "unknown"),
+                    "gpu_enabled": gpu is not None,
+                }
             }
-        }
 
-        if is_instance_segmentation:
-            # Instance segmentation: download + run-instance-segmentation
-            output_file = temp_dir / f"{uid}.geojson"
-            try:
+            if is_instance_segmentation:
+                # Instance segmentation: download + run-instance-segmentation
                 download_result = await download_images(
                     image_file, win_a, win_b, bbox, context
                 )
@@ -398,15 +402,7 @@ class InferenceService:
 
                 return data
 
-            finally:
-                image_file.unlink(missing_ok=True)
-                output_file.unlink(missing_ok=True)
-
-        # Standard semantic segmentation pipeline
-        inference_file = temp_dir / f"{uid}.inference.tif"
-        polygon_file = temp_dir / f"{uid}.{'ndjson' if ndjson else 'json'}"
-
-        try:
+            # Standard semantic segmentation pipeline
             inference_result = await execute_inference_pipeline(
                 image_file,
                 inference_file,
@@ -467,11 +463,6 @@ class InferenceService:
                 )
 
             return data
-
-        finally:
-            image_file.unlink(missing_ok=True)
-            inference_file.unlink(missing_ok=True)
-            polygon_file.unlink(missing_ok=True)
 
     # --- Internal Helper Methods ---
 

--- a/server/tests/test_feedback.py
+++ b/server/tests/test_feedback.py
@@ -1,0 +1,143 @@
+"""Behavioral tests for the /v1/feedback/* endpoints."""
+
+import pytest
+from app.db.models import FeedbackRecord
+from fastapi.testclient import TestClient
+
+TILE_RATING_URL = "/v1/feedback/tile-rating"
+TELL_US_MORE_URL = "/v1/feedback/tell-us-more"
+CONTRIBUTE_URL = "/v1/feedback/contribute"
+AREA_SUMMARY_URL = "/v1/feedback/area-summary"
+
+VALID_BBOX = [12.0, 48.0, 13.0, 49.0]
+VALID_BBOX_STR = "12.0,48.0,13.0,49.0"
+
+VALID_TILE_RATING = {
+    "rating": 2,
+    "bbox": VALID_BBOX,
+    "resolution": 76.4,
+}
+
+VALID_TELL_US_MORE = {
+    "quality_feedback": "Boundaries look reasonable but miss some small parcels.",
+    "use_case": "Crop monitoring for smallholder farms.",
+    "bbox": VALID_BBOX,
+    "resolution": 76.4,
+}
+
+VALID_CONTRIBUTE = {
+    "contribution_types": ["annotator", "share_data"],
+    "name": "Jane Doe",
+    "email": "jane@example.com",
+}
+
+
+@pytest.fixture()
+def feedback_client(client: TestClient) -> TestClient:
+    """Test client with a clean FeedbackRecord table for area-summary isolation."""
+    for item in FeedbackRecord.scan():
+        item.delete()
+    return client
+
+
+# ---------------------------------------------------------------------------
+# tile-rating
+# ---------------------------------------------------------------------------
+
+
+def test_tile_rating_success(client: TestClient) -> None:
+    """A valid rating returns 200 with rating_id and status='created'."""
+    response = client.post(TILE_RATING_URL, json=VALID_TILE_RATING)
+    assert response.status_code == 200
+    data = response.json()
+    assert "rating_id" in data
+    assert data["status"] == "created"
+
+
+def test_tile_rating_invalid_rating_value(client: TestClient) -> None:
+    """A rating outside [1, 2, 3] is rejected with 400 (app validation handler)."""
+    payload = {**VALID_TILE_RATING, "rating": 4}
+    response = client.post(TILE_RATING_URL, json=payload)
+    assert response.status_code == 400
+
+
+def test_tile_rating_invalid_bbox_order(client: TestClient) -> None:
+    """A bbox where minLng > maxLng is rejected with 400 (app validation handler)."""
+    payload = {**VALID_TILE_RATING, "bbox": [13.0, 48.0, 12.0, 49.0]}
+    response = client.post(TILE_RATING_URL, json=payload)
+    assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# tell-us-more
+# ---------------------------------------------------------------------------
+
+
+def test_tell_us_more_success(client: TestClient) -> None:
+    """A valid submission returns 200 with feedback_id and status='submitted'."""
+    response = client.post(TELL_US_MORE_URL, json=VALID_TELL_US_MORE)
+    assert response.status_code == 200
+    data = response.json()
+    assert "feedback_id" in data
+    assert data["status"] == "submitted"
+
+
+def test_tell_us_more_invalid_email(client: TestClient) -> None:
+    """An email lacking '@' is rejected with 400 (app validation handler)."""
+    payload = {**VALID_TELL_US_MORE, "email": "not-an-email"}
+    response = client.post(TELL_US_MORE_URL, json=payload)
+    assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# contribute
+# ---------------------------------------------------------------------------
+
+
+def test_contribute_success(client: TestClient) -> None:
+    """A valid submission returns 200 with contribution_id and submitted status."""
+    response = client.post(CONTRIBUTE_URL, json=VALID_CONTRIBUTE)
+    assert response.status_code == 200
+    data = response.json()
+    assert "contribution_id" in data
+    assert data["status"] == "submitted"
+
+
+def test_contribute_duplicate_types(client: TestClient) -> None:
+    """Duplicate contribution_types values are rejected with 400."""
+    payload = {**VALID_CONTRIBUTE, "contribution_types": ["annotator", "annotator"]}
+    response = client.post(CONTRIBUTE_URL, json=payload)
+    assert response.status_code == 400
+
+
+def test_contribute_invalid_email(client: TestClient) -> None:
+    """An email lacking '@' is rejected with 400 (app validation handler)."""
+    payload = {**VALID_CONTRIBUTE, "email": "notvalid"}
+    response = client.post(CONTRIBUTE_URL, json=payload)
+    assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# area-summary
+# ---------------------------------------------------------------------------
+
+
+def test_area_summary_404_when_no_ratings(feedback_client: TestClient) -> None:
+    """area-summary returns 404 when no ratings exist for the requested bbox."""
+    response = feedback_client.get(AREA_SUMMARY_URL, params={"bbox": VALID_BBOX_STR})
+    assert response.status_code == 404
+
+
+def test_area_summary_returns_aggregated_ratings(feedback_client: TestClient) -> None:
+    """After seeding two tile ratings, area-summary returns 200 with correct stats."""
+    feedback_client.post(TILE_RATING_URL, json={**VALID_TILE_RATING, "rating": 3})
+    feedback_client.post(TILE_RATING_URL, json={**VALID_TILE_RATING, "rating": 1})
+
+    response = feedback_client.get(AREA_SUMMARY_URL, params={"bbox": VALID_BBOX_STR})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_ratings"] == 2
+    assert data["average_rating"] == pytest.approx(2.0)
+    dist = {item["level"]: item["count"] for item in data["rating_distribution"]}
+    assert dist[1] == 1
+    assert dist[3] == 1


### PR DESCRIPTION
- POST /v1/feedback/tile-rating — 1-3 quality rating with bbox and zoom
- POST /v1/feedback/tell-us-more — detailed quality feedback form
- POST /v1/feedback/contribute — community contribution interest form
- GET /v1/feedback/area-summary — aggregate rating stats by bbox

Adds FeedbackRecord PynamoDB model (NumberAttribute zoom, source_ip field for future dedup, datetime.now(UTC) for created_at). Registers FeedbackRecord in database.py TABLES tuple. Combines v1 routers in __init__.py without changing main.py.