### PR TITLE
Add tags support and rename tile-rating to rating endpoint

### DIFF
--- a/server/app/api/v1/feedback.py
+++ b/server/app/api/v1/feedback.py
@@ -1,4 +1,5 @@
 import json
+from collections import Counter
 
 from fastapi import APIRouter, HTTPException, status
 from pynamodb.exceptions import PutError, ScanError
@@ -34,7 +35,7 @@ def _bboxes_intersect(a: list[float], b: list[float]) -> bool:
 
 
 @feedback_router.post(
-    "/tile-rating",
+    "/rating",
     status_code=status.HTTP_200_OK,
 )
 async def submit_tile_rating(
@@ -175,6 +176,7 @@ async def get_area_summary(
     **Rate limit:** 60 requests per minute per IP.
     """
     matching_ratings: list[int] = []
+    matching_tags: list[str] = []
 
     try:
         scan_results = list(
@@ -200,6 +202,9 @@ async def get_area_summary(
             rating = record_payload.get("rating")
             if isinstance(rating, int) and rating in (1, 2, 3):
                 matching_ratings.append(rating)
+            tags = record_payload.get("tags")
+            if isinstance(tags, list):
+                matching_tags.extend(tags)
 
     if not matching_ratings:
         raise HTTPException(
@@ -209,6 +214,11 @@ async def get_area_summary(
 
     total = len(matching_ratings)
     avg = round(sum(matching_ratings) / total, 2)
+    tag_counter = Counter(matching_tags)
+    tag_counts: list[dict[str, str | int]] = [
+        {"tag": tag, "count": count}
+        for tag, count in sorted(tag_counter.items(), key=lambda x: -x[1])
+    ]
 
     return AreaSummaryResponse(
         bbox=bbox,
@@ -219,4 +229,5 @@ async def get_area_summary(
             {"level": 2, "count": matching_ratings.count(2)},
             {"level": 3, "count": matching_ratings.count(3)},
         ],
+        tag_counts=tag_counts,
     )

--- a/server/app/schemas/feedback.py
+++ b/server/app/schemas/feedback.py
@@ -40,11 +40,11 @@ class TileRatingRequest(BaseModel):
         ),
     )
 
-    tags: list[str] | None = Field(
-        default=None,
+    tags: list[str] = Field(
+        ...,
         min_length=1,
         description=(
-            "Optional qualitative tags elaborating on the rating. "
+            "Qualitative tags elaborating on the rating. "
             "Rating 3 (Good): clean_boundaries, good_shapes, better_than_expected. "
             "Rating 1/2 (Poor/Acceptable): over_merged, fragmented, missing_fields, "
             "false_positives, jagged_boundaries, tiling_artifacts."
@@ -63,8 +63,6 @@ class TileRatingRequest(BaseModel):
 
     @model_validator(mode="after")
     def validate_tags_match_rating(self) -> Self:
-        if self.tags is None:
-            return self
         tag_set = set(self.tags)
         if len(tag_set) != len(self.tags):
             raise ValueError("tags must not contain duplicates")

--- a/server/app/schemas/feedback.py
+++ b/server/app/schemas/feedback.py
@@ -1,6 +1,20 @@
-from typing import Literal
+from typing import Literal, Self
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+_GOOD_TAGS: frozenset[str] = frozenset({
+    "clean_boundaries",
+    "good_shapes",
+    "better_than_expected",
+})
+_POOR_TAGS: frozenset[str] = frozenset({
+    "over_merged",
+    "fragmented",
+    "missing_fields",
+    "false_positives",
+    "jagged_boundaries",
+    "tiling_artifacts",
+})
 
 
 class TileRatingRequest(BaseModel):
@@ -9,7 +23,7 @@ class TileRatingRequest(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True)
 
     rating: Literal[1, 2, 3] = Field(
-        ..., description="Quality rating: 1=Not Great, 2=Ok, 3=Great!"
+        ..., description="Quality rating: 1: Poor, 2: Acceptable, 3: Good"
     )
     bbox: list[float] = Field(
         ...,
@@ -26,6 +40,17 @@ class TileRatingRequest(BaseModel):
         ),
     )
 
+    tags: list[str] | None = Field(
+        default=None,
+        min_length=1,
+        description=(
+            "Optional qualitative tags elaborating on the rating. "
+            "Rating 3 (Good): clean_boundaries, good_shapes, better_than_expected. "
+            "Rating 1/2 (Poor/Acceptable): over_merged, fragmented, missing_fields, "
+            "false_positives, jagged_boundaries, tiling_artifacts."
+        ),
+    )
+
     @field_validator("bbox")
     @classmethod
     def validate_bbox(cls, v: list[float]) -> list[float]:
@@ -35,6 +60,22 @@ class TileRatingRequest(BaseModel):
         if min_lat > max_lat:
             raise ValueError("bbox minLat must be <= maxLat")
         return v
+
+    @model_validator(mode="after")
+    def validate_tags_match_rating(self) -> Self:
+        if self.tags is None:
+            return self
+        tag_set = set(self.tags)
+        if len(tag_set) != len(self.tags):
+            raise ValueError("tags must not contain duplicates")
+        allowed = _GOOD_TAGS if self.rating == 3 else _POOR_TAGS
+        invalid = tag_set - allowed
+        if invalid:
+            raise ValueError(
+                f"Invalid tags for rating {self.rating}: {sorted(invalid)}. "
+                f"Allowed: {sorted(allowed)}"
+            )
+        return self
 
 
 class TileRatingResponse(BaseModel):
@@ -203,5 +244,13 @@ class AreaSummaryResponse(BaseModel):
             "Count of ratings for each value: "
             '[{"level": 1, "count": n}, {"level": 2, "count": n}, '
             '{"level": 3, "count": n}]'
+        ),
+    )
+    tag_counts: list[dict[str, str | int]] = Field(
+        default_factory=list,
+        description=(
+            "Frequency of each tag across all ratings in the area, "
+            "sorted by count descending. Only tags that appear at least once "
+            "are included."
         ),
     )

--- a/server/tests/test_feedback.py
+++ b/server/tests/test_feedback.py
@@ -4,7 +4,7 @@ import pytest
 from app.db.models import FeedbackRecord
 from fastapi.testclient import TestClient
 
-TILE_RATING_URL = "/v1/feedback/tile-rating"
+TILE_RATING_URL = "/v1/feedback/rating"
 TELL_US_MORE_URL = "/v1/feedback/tell-us-more"
 CONTRIBUTE_URL = "/v1/feedback/contribute"
 AREA_SUMMARY_URL = "/v1/feedback/area-summary"
@@ -66,6 +66,62 @@ def test_tile_rating_invalid_bbox_order(client: TestClient) -> None:
     payload = {**VALID_TILE_RATING, "bbox": [13.0, 48.0, 12.0, 49.0]}
     response = client.post(TILE_RATING_URL, json=payload)
     assert response.status_code == 400
+
+
+def test_tile_rating_with_valid_good_tags(client: TestClient) -> None:
+    """Tags valid for rating 3 (Good) are accepted."""
+    payload = {
+        **VALID_TILE_RATING,
+        "rating": 3,
+        "tags": ["clean_boundaries", "good_shapes"],
+    }
+    response = client.post(TILE_RATING_URL, json=payload)
+    assert response.status_code == 200
+
+
+def test_tile_rating_with_valid_poor_tags(client: TestClient) -> None:
+    """Tags valid for rating 1 (Poor) are accepted."""
+    payload = {
+        **VALID_TILE_RATING,
+        "rating": 1,
+        "tags": ["fragmented", "missing_fields"],
+    }
+    response = client.post(TILE_RATING_URL, json=payload)
+    assert response.status_code == 200
+
+
+def test_tile_rating_wrong_tags_for_rating(client: TestClient) -> None:
+    """Poor tags submitted with rating 3 are rejected with 400."""
+    payload = {**VALID_TILE_RATING, "rating": 3, "tags": ["fragmented"]}
+    response = client.post(TILE_RATING_URL, json=payload)
+    assert response.status_code == 400
+
+
+def test_tile_rating_duplicate_tags_rejected(client: TestClient) -> None:
+    """Duplicate tag values are rejected with 400."""
+    payload = {**VALID_TILE_RATING, "rating": 1, "tags": ["fragmented", "fragmented"]}
+    response = client.post(TILE_RATING_URL, json=payload)
+    assert response.status_code == 400
+
+
+def test_tile_rating_acceptable_rating_accepts_poor_tags(client: TestClient) -> None:
+    """Rating 2 (Acceptable) accepts the poor-tag set (validator else-branch)."""
+    payload = {**VALID_TILE_RATING, "rating": 2, "tags": ["jagged_boundaries"]}
+    response = client.post(TILE_RATING_URL, json=payload)
+    assert response.status_code == 200
+
+
+def test_tile_rating_empty_tags_list_rejected(client: TestClient) -> None:
+    """An empty tags list is rejected (min_length=1 constraint)."""
+    payload = {**VALID_TILE_RATING, "rating": 1, "tags": []}
+    response = client.post(TILE_RATING_URL, json=payload)
+    assert response.status_code == 400
+
+
+def test_old_tile_rating_path_returns_404(client: TestClient) -> None:
+    """The pre-rename /tile-rating path no longer exists (PR #80 rename)."""
+    response = client.post("/v1/feedback/tile-rating", json=VALID_TILE_RATING)
+    assert response.status_code == 404
 
 
 # ---------------------------------------------------------------------------
@@ -130,8 +186,13 @@ def test_area_summary_404_when_no_ratings(feedback_client: TestClient) -> None:
 
 def test_area_summary_returns_aggregated_ratings(feedback_client: TestClient) -> None:
     """After seeding two tile ratings, area-summary returns 200 with correct stats."""
-    feedback_client.post(TILE_RATING_URL, json={**VALID_TILE_RATING, "rating": 3})
-    feedback_client.post(TILE_RATING_URL, json={**VALID_TILE_RATING, "rating": 1})
+    feedback_client.post(
+        TILE_RATING_URL,
+        json={**VALID_TILE_RATING, "rating": 3, "tags": ["clean_boundaries"]},
+    )
+    feedback_client.post(
+        TILE_RATING_URL, json={**VALID_TILE_RATING, "rating": 1, "tags": ["fragmented"]}
+    )
 
     response = feedback_client.get(AREA_SUMMARY_URL, params={"bbox": VALID_BBOX_STR})
     assert response.status_code == 200
@@ -141,3 +202,40 @@ def test_area_summary_returns_aggregated_ratings(feedback_client: TestClient) ->
     dist = {item["level"]: item["count"] for item in data["rating_distribution"]}
     assert dist[1] == 1
     assert dist[3] == 1
+    assert "tag_counts" in data
+    tag_map = {item["tag"]: item["count"] for item in data["tag_counts"]}
+    assert tag_map["clean_boundaries"] == 1
+    assert tag_map["fragmented"] == 1
+
+
+def test_area_summary_tag_counts_empty_when_no_tags(
+    feedback_client: TestClient,
+) -> None:
+    """area-summary returns tag_counts as empty list when ratings have no tags."""
+    feedback_client.post(TILE_RATING_URL, json=VALID_TILE_RATING)
+
+    response = feedback_client.get(AREA_SUMMARY_URL, params={"bbox": VALID_BBOX_STR})
+    assert response.status_code == 200
+    assert response.json()["tag_counts"] == []
+
+
+def test_area_summary_tag_counts_sorted_descending(
+    feedback_client: TestClient,
+) -> None:
+    """tag_counts is sorted by count descending — most frequent tag appears first."""
+    # Seed: "fragmented" appears 3x, "missing_fields" appears 1x
+    for _ in range(3):
+        feedback_client.post(
+            TILE_RATING_URL,
+            json={**VALID_TILE_RATING, "rating": 1, "tags": ["fragmented"]},
+        )
+    feedback_client.post(
+        TILE_RATING_URL,
+        json={**VALID_TILE_RATING, "rating": 1, "tags": ["missing_fields"]},
+    )
+
+    response = feedback_client.get(AREA_SUMMARY_URL, params={"bbox": VALID_BBOX_STR})
+    assert response.status_code == 200
+    tag_counts = response.json()["tag_counts"]
+    assert [item["tag"] for item in tag_counts] == ["fragmented", "missing_fields"]
+    assert [item["count"] for item in tag_counts] == [3, 1]

--- a/server/tests/test_feedback.py
+++ b/server/tests/test_feedback.py
@@ -16,6 +16,7 @@ VALID_TILE_RATING = {
     "rating": 2,
     "bbox": VALID_BBOX,
     "resolution": 76.4,
+    "tags": ["fragmented"],
 }
 
 VALID_TELL_US_MORE = {
@@ -124,6 +125,13 @@ def test_old_tile_rating_path_returns_404(client: TestClient) -> None:
     assert response.status_code == 404
 
 
+def test_tile_rating_missing_tags_rejected(client: TestClient) -> None:
+    """A submission without `tags` is rejected (tags is required per spec)."""
+    payload = {k: v for k, v in VALID_TILE_RATING.items() if k != "tags"}
+    response = client.post(TILE_RATING_URL, json=payload)
+    assert response.status_code == 400
+
+
 # ---------------------------------------------------------------------------
 # tell-us-more
 # ---------------------------------------------------------------------------
@@ -206,17 +214,6 @@ def test_area_summary_returns_aggregated_ratings(feedback_client: TestClient) ->
     tag_map = {item["tag"]: item["count"] for item in data["tag_counts"]}
     assert tag_map["clean_boundaries"] == 1
     assert tag_map["fragmented"] == 1
-
-
-def test_area_summary_tag_counts_empty_when_no_tags(
-    feedback_client: TestClient,
-) -> None:
-    """area-summary returns tag_counts as empty list when ratings have no tags."""
-    feedback_client.post(TILE_RATING_URL, json=VALID_TILE_RATING)
-
-    response = feedback_client.get(AREA_SUMMARY_URL, params={"bbox": VALID_BBOX_STR})
-    assert response.status_code == 200
-    assert response.json()["tag_counts"] == []
 
 
 def test_area_summary_tag_counts_sorted_descending(


### PR DESCRIPTION
- Rename POST /v1/feedback/tile-rating to /v1/feedback/rating
- Add optional `tags` field on TileRatingRequest with rating-conditional validation (rating 3 -> good tags; rating 1/2 -> poor tags) and duplicate-tag rejection via @model_validator
- Update rating label descriptions to Poor/Acceptable/Good
- Aggregate `tag_counts` (sorted descending by count) in AreaSummaryResponse
- Add 9 new behavioral tests covering tag validation, endpoint rename, empty-list rejection, rating-2 else-branch, and tag_counts ordering