### PR TITLE
Add confidence_threshold + sync tell-us-more with rating schema

### DIFF
--- a/server/app/schemas/feedback.py
+++ b/server/app/schemas/feedback.py
@@ -39,6 +39,15 @@ class TileRatingRequest(BaseModel):
             "Indicates how closely the user was inspecting the data."
         ),
     )
+    confidence_threshold: int = Field(
+        ...,
+        ge=0,
+        le=100,
+        description=(
+            "Confidence threshold (0-100 %) that was selected when the user "
+            "submitted the rating."
+        ),
+    )
 
     tags: list[str] = Field(
         ...,

--- a/server/app/schemas/feedback.py
+++ b/server/app/schemas/feedback.py
@@ -98,10 +98,13 @@ class TileRatingResponse(BaseModel):
     )
 
 
-class TellUsMoreRequest(BaseModel):
-    """Request body for the tell-us-more endpoint."""
+class TellUsMoreRequest(TileRatingRequest):
+    """Request body for the tell-us-more endpoint.
 
-    model_config = ConfigDict(str_strip_whitespace=True)
+    Inherits all required fields and validators from TileRatingRequest
+    (rating, bbox, resolution, confidence_threshold, tags) and adds the
+    long-form prose fields plus optional submitter contact info.
+    """
 
     quality_feedback: str = Field(
         ...,
@@ -115,24 +118,6 @@ class TellUsMoreRequest(BaseModel):
         max_length=2000,
         description="How would you use field boundaries? Describe your use case.",
     )
-    bbox: list[float] = Field(
-        ...,
-        min_length=4,
-        max_length=4,
-        description="WGS84 viewport bbox [minLng, minLat, maxLng, maxLat]",
-    )
-    resolution: float = Field(
-        ...,
-        ge=0,
-        description=(
-            "Pixel resolution in meters at time of submission. "
-            "Indicates how closely the user was inspecting the data."
-        ),
-    )
-    rating: Literal[1, 2, 3] | None = Field(
-        default=None,
-        description="Optional rating carried over from the tile-rating form",
-    )
     name: str | None = Field(
         default=None, max_length=200, description="Optional submitter name"
     )
@@ -142,16 +127,6 @@ class TellUsMoreRequest(BaseModel):
     organization: str | None = Field(
         default=None, max_length=200, description="Optional submitter organization"
     )
-
-    @field_validator("bbox")
-    @classmethod
-    def validate_bbox(cls, v: list[float]) -> list[float]:
-        min_lng, min_lat, max_lng, max_lat = v
-        if min_lng > max_lng:
-            raise ValueError("bbox minLng must be <= maxLng")
-        if min_lat > max_lat:
-            raise ValueError("bbox minLat must be <= maxLat")
-        return v
 
     @field_validator("email")
     @classmethod

--- a/server/tests/test_feedback.py
+++ b/server/tests/test_feedback.py
@@ -16,6 +16,7 @@ VALID_TILE_RATING = {
     "rating": 2,
     "bbox": VALID_BBOX,
     "resolution": 76.4,
+    "confidence_threshold": 50,
     "tags": ["fragmented"],
 }
 
@@ -128,6 +129,33 @@ def test_old_tile_rating_path_returns_404(client: TestClient) -> None:
 def test_tile_rating_missing_tags_rejected(client: TestClient) -> None:
     """A submission without `tags` is rejected (tags is required per spec)."""
     payload = {k: v for k, v in VALID_TILE_RATING.items() if k != "tags"}
+    response = client.post(TILE_RATING_URL, json=payload)
+    assert response.status_code == 400
+
+
+def test_tile_rating_missing_confidence_threshold_rejected(client: TestClient) -> None:
+    """A submission without `confidence_threshold` is rejected (required per spec)."""
+    payload = {
+        k: v for k, v in VALID_TILE_RATING.items() if k != "confidence_threshold"
+    }
+    response = client.post(TILE_RATING_URL, json=payload)
+    assert response.status_code == 400
+
+
+def test_tile_rating_confidence_threshold_below_zero_rejected(
+    client: TestClient,
+) -> None:
+    """A confidence_threshold below 0 is rejected (must be 0-100)."""
+    payload = {**VALID_TILE_RATING, "confidence_threshold": -1}
+    response = client.post(TILE_RATING_URL, json=payload)
+    assert response.status_code == 400
+
+
+def test_tile_rating_confidence_threshold_above_hundred_rejected(
+    client: TestClient,
+) -> None:
+    """A confidence_threshold above 100 is rejected (must be 0-100)."""
+    payload = {**VALID_TILE_RATING, "confidence_threshold": 101}
     response = client.post(TILE_RATING_URL, json=payload)
     assert response.status_code == 400
 

--- a/server/tests/test_feedback.py
+++ b/server/tests/test_feedback.py
@@ -23,8 +23,11 @@ VALID_TILE_RATING = {
 VALID_TELL_US_MORE = {
     "quality_feedback": "Boundaries look reasonable but miss some small parcels.",
     "use_case": "Crop monitoring for smallholder farms.",
+    "rating": 2,
     "bbox": VALID_BBOX,
     "resolution": 76.4,
+    "confidence_threshold": 50,
+    "tags": ["fragmented"],
 }
 
 VALID_CONTRIBUTE = {
@@ -177,6 +180,20 @@ def test_tell_us_more_success(client: TestClient) -> None:
 def test_tell_us_more_invalid_email(client: TestClient) -> None:
     """An email lacking '@' is rejected with 400 (app validation handler)."""
     payload = {**VALID_TELL_US_MORE, "email": "not-an-email"}
+    response = client.post(TELL_US_MORE_URL, json=payload)
+    assert response.status_code == 400
+
+
+def test_tell_us_more_missing_tags_rejected(client: TestClient) -> None:
+    """Tags is required on tell-us-more (inherited from TileRatingRequest)."""
+    payload = {k: v for k, v in VALID_TELL_US_MORE.items() if k != "tags"}
+    response = client.post(TELL_US_MORE_URL, json=payload)
+    assert response.status_code == 400
+
+
+def test_tell_us_more_wrong_tags_for_rating_rejected(client: TestClient) -> None:
+    """Tag-set validator from TileRatingRequest applies on tell-us-more too."""
+    payload = {**VALID_TELL_US_MORE, "rating": 3, "tags": ["fragmented"]}
     response = client.post(TELL_US_MORE_URL, json=payload)
     assert response.status_code == 400
 


### PR DESCRIPTION
Sync with the upstream openapi.yaml change (commit 606baae) that adds a new required `confidence_threshold` field to TileRatingRequest. Captures the prediction-confidence slider value (0-100 %) the user had selected at the time of rating.

- Schema: add `confidence_threshold: int` with ge=0/le=100 validation
- Tests: add to VALID_TILE_RATING fixture, plus 3 negative tests (missing field, below 0, above 100)