### PR TITLE
feat: add required year field to rating endpoint

### DIFF
--- a/server/app/schemas/feedback.py
+++ b/server/app/schemas/feedback.py
@@ -48,6 +48,12 @@ class TileRatingRequest(BaseModel):
             "submitted the rating."
         ),
     )
+    year: int = Field(
+        ...,
+        ge=2024,
+        le=2025,
+        description="The year of the fields the user was rating.",
+    )
 
     tags: list[str] = Field(
         ...,

--- a/server/tests/test_feedback.py
+++ b/server/tests/test_feedback.py
@@ -17,6 +17,7 @@ VALID_TILE_RATING = {
     "bbox": VALID_BBOX,
     "resolution": 76.4,
     "confidence_threshold": 50,
+    "year": 2025,
     "tags": ["fragmented"],
 }
 
@@ -27,6 +28,7 @@ VALID_TELL_US_MORE = {
     "bbox": VALID_BBOX,
     "resolution": 76.4,
     "confidence_threshold": 50,
+    "year": 2025,
     "tags": ["fragmented"],
 }
 
@@ -159,6 +161,27 @@ def test_tile_rating_confidence_threshold_above_hundred_rejected(
 ) -> None:
     """A confidence_threshold above 100 is rejected (must be 0-100)."""
     payload = {**VALID_TILE_RATING, "confidence_threshold": 101}
+    response = client.post(TILE_RATING_URL, json=payload)
+    assert response.status_code == 400
+
+
+def test_tile_rating_missing_year_rejected(client: TestClient) -> None:
+    """A submission without `year` is rejected (required per spec)."""
+    payload = {k: v for k, v in VALID_TILE_RATING.items() if k != "year"}
+    response = client.post(TILE_RATING_URL, json=payload)
+    assert response.status_code == 400
+
+
+def test_tile_rating_year_before_2024_rejected(client: TestClient) -> None:
+    """Year before 2024 is rejected (must be 2024-2025 per spec)."""
+    payload = {**VALID_TILE_RATING, "year": 2023}
+    response = client.post(TILE_RATING_URL, json=payload)
+    assert response.status_code == 400
+
+
+def test_tile_rating_year_after_2025_rejected(client: TestClient) -> None:
+    """Year after 2025 is rejected (must be 2024-2025 per spec)."""
+    payload = {**VALID_TILE_RATING, "year": 2026}
     response = client.post(TILE_RATING_URL, json=payload)
     assert response.status_code == 400
 


### PR DESCRIPTION
Sync with the upstream openapi.yaml change (PR #84) that adds a new required `year` field to TileRatingRequest. Captures the year of the field-boundary inference output the user was viewing when they submitted the rating. Constrained to 2024-2025 to match the years for which FTW publishes inference outputs. Inherited automatically by TellUsMoreRequest via the existing class hierarchy.

- Schema: add `year: int` with ge=2024/le=2025 validation
- Tests: add to VALID_TILE_RATING and VALID_TELL_US_MORE fixtures, plus 3 negative tests (missing field, before 2024, after 2025)